### PR TITLE
Remove expenses feature and reindex tabs

### DIFF
--- a/expenses.csv
+++ b/expenses.csv
@@ -1,8 +1,0 @@
-Type,Item,Amount,Date
-Bill,Clement,800.0,2025-05-25
-Bill,Cleaner,300.0,2025-06-09
-Bill,Internet,500.0,2025-06-13
-Salary,Internet,300.0,2025-06-13
-Marketing,Internet,250.0,2025-06-13
-Salary,Clement,500.0,2025-06-18
-Salary,Clement,500.0,2025-06-20


### PR DESCRIPTION
## Summary
- remove expenses data loader and tab
- shift reminder, contract, send email, course, and marking tabs left
- delete unused expenses.csv asset

## Testing
- `python -m py_compile email.py email_utils.py pdf_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f685cffc832186e18561703a028e