### PR TITLE
Split PDF generation and download steps

### DIFF
--- a/email.py
+++ b/email.py
@@ -736,7 +736,7 @@ with tabs[3]:
         if len(txt) == 1 and not txt.isalnum(): return False
         return True
 
-    if st.button("Generate & Download PDF"):
+    if st.button("Generate PDF"):
         paid    = paid_input
         balance = balance_input
         total   = total_input
@@ -828,13 +828,16 @@ This Payment Agreement is entered into on [DATE] for [CLASS] students of Learn L
         else:
             pdf_bytes = bytes(output_data)
 
+        st.session_state["receipt_pdf"] = pdf_bytes
+        st.success("✅ PDF generated and ready to download.")
+
+    if "receipt_pdf" in st.session_state:
         st.download_button(
             "📄 Download PDF",
-            data=pdf_bytes,
+            data=st.session_state["receipt_pdf"],
             file_name=f"{selected_name.replace(' ', '_')}_receipt_contract.pdf",
             mime="application/pdf"
         )
-        st.success("✅ PDF generated and ready to download.")
 
 with tabs[4]:
 


### PR DESCRIPTION
## Summary
- Separate PDF generation from download using session state
- Add download button outside generation step with confirmation message

## Testing
- `python -m py_compile email.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1c56d577883218549569fd19bff84