### PR TITLE
Use shared safe_pdf helper

### DIFF
--- a/email.py
+++ b/email.py
@@ -588,12 +588,6 @@ with tabs[4]:
     import tempfile, os
 
 
-    # ---- Helper: Ensure all text in PDF is latin-1 safe ----
-    def safe_pdf(text):
-        if not text:
-            return ""
-        return "".join(c if ord(c) < 256 else "?" for c in str(text))
-
     # QR Code generation uses shared utility function make_qr_code
 
 


### PR DESCRIPTION
## Summary
- remove redundant `safe_pdf` definition inside tab 4
- rely on the shared `safe_pdf` utility for PDF-safe strings

## Testing
- `python -m py_compile email.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49adf067083218f933346d5c10472