### PR TITLE
Handle 9-digit Ghana phone numbers without leading zero

### DIFF
--- a/email.py
+++ b/email.py
@@ -55,17 +55,22 @@ def make_qr_code(url):
     return tmp.name
 
 def clean_phone(phone):
-    """Normalize Ghana phone numbers to the `233XXXXXXXXX` format.
+    """Normalize Ghana phone numbers to the ``233XXXXXXXXX`` format.
 
     Acceptable inputs:
       - ``0XXXXXXXXX``
       - ``233XXXXXXXXX``
       - ``+233XXXXXXXXX``
+      - ``XXXXXXXXX`` (9 digits starting with 2, 5, or 9)
 
     Any other value returns ``None``.
     """
     # Remove all non-digit characters (spaces, dashes, plus signs, etc.)
     digits = re.sub(r"\D", "", str(phone))
+
+    # Handle 9-digit numbers missing the leading zero
+    if len(digits) == 9 and digits[:1] in {"2", "5", "9"}:
+        digits = "0" + digits
 
     if digits.startswith("0") and len(digits) == 10:
         return "233" + digits[1:]

--- a/tests/test_clean_phone.py
+++ b/tests/test_clean_phone.py
@@ -1,0 +1,33 @@
+import ast
+import pathlib
+import re
+
+
+def get_clean_phone():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_node = next(
+        node for node in module_ast.body if isinstance(node, ast.FunctionDef) and node.name == "clean_phone"
+    )
+    module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(module, filename="email.py", mode="exec")
+    ns = {"re": re}
+    exec(code, ns)
+    return ns["clean_phone"]
+
+clean_phone = get_clean_phone()
+
+
+def test_clean_phone_handles_missing_zero():
+    assert clean_phone("241234567") == "233241234567"
+    assert clean_phone("512345678") == "233512345678"
+    assert clean_phone("912345678") == "233912345678"
+
+
+def test_clean_phone_invalid_9_digit_number():
+    assert clean_phone("123456789") is None
+
+
+def test_clean_phone_existing_formats():
+    assert clean_phone("+233241234567") == "233241234567"
+    assert clean_phone("0241234567") == "233241234567"


### PR DESCRIPTION
## Summary
- Extend `clean_phone` to accept 9-digit Ghanaian numbers starting with 2, 5, or 9 by prefixing a zero before validation.
- Document new input format for `clean_phone` and keep normalized output as `233XXXXXXXXX`.
- Add tests covering 9-digit numbers, existing formats, and invalid cases.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49f4c79408321abcf1ac319dc9393