### PR TITLE
feat: add branded email reminders

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Learn Language Education Academy</title>
+</head>
+<body style="font-family: Arial, sans-serif; margin:0; padding:0; background-color:#ffffff;">
+  <div style="text-align:center; padding:20px;">
+    <img src="data:image/png;base64,{logo_base64}" alt="Learn Language Education Academy" style="max-width:150px;">
+  </div>
+  <div style="padding:20px;">
+    {content}
+  </div>
+  <div style="font-size:12px;color:#555;text-align:center;padding:20px;background-color:#f7f7f7;">
+    <strong>{school_name}</strong><br/>
+    {school_address}<br/>
+    Phone: {school_phone}<br/>
+    <a href="{school_website}">{school_website}</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable HTML email template with logo and contact details
- allow reminder workflow to send branded emails with optional attachments
- toggle between mailto links and full email sending

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1ce78388321b023a0925020424e