### PR TITLE
Remove tab state key and clean session tracking

### DIFF
--- a/email.py
+++ b/email.py
@@ -242,10 +242,7 @@ tab_titles = [
 if "active_tab" not in st.session_state:
     st.session_state["active_tab"] = 3  # Contract tab index
 
-# Ensure the previously active tab remains selected on rerun
-st.session_state.setdefault("main_tabs", tab_titles[st.session_state["active_tab"]])
-
-tabs = st.tabs(tab_titles, key="main_tabs")
+tabs = st.tabs(tab_titles)
 
 # ==== TAB 0: PENDING STUDENTS ====
 with tabs[0]:
@@ -280,8 +277,6 @@ with tabs[0]:
         filt.to_csv(index=False),
         file_name="pending_students.csv"
     )
-    if st.session_state.get("main_tabs") == tab_titles[0]:
-        st.session_state["active_tab"] = 0
 
 # ==== END OF STAGE 3 (TAB 0) ====
 
@@ -308,8 +303,6 @@ with tabs[1]:
         filt.to_csv(index=False),
         file_name="all_students.csv"
     )
-    if st.session_state.get("main_tabs") == tab_titles[1]:
-        st.session_state["active_tab"] = 1
 
 # ==== TAB 2: WHATSAPP REMINDERS ====
 with tabs[2]:
@@ -518,9 +511,6 @@ with tabs[2]:
         df_links[["Name", "Student Code", "Phone", "Email", "Level", "Balance (GHS)", "Due Date", "Days Left", "WhatsApp Link", "Email Link"]].to_csv(index=False),
         file_name="debtor_whatsapp_links.csv",
     )
-# Update active tab when this tab is viewed
-    if st.session_state.get("main_tabs") == tab_titles[2]:
-        st.session_state["active_tab"] = 2
 
 
 # ==== TAB 3: CONTRACT & RECEIPT PDF ====
@@ -743,9 +733,6 @@ This Payment Agreement is entered into on [DATE] for [CLASS] students of Learn L
         )
         st.success("✅ PDF generated and ready to download.")
 
-    if st.session_state.get("main_tabs") == tab_titles[3]:
-        st.session_state["active_tab"] = 3
-
 # ==== TAB 4: SEND EMAIL / LETTER ====
 with tabs[4]:
     from datetime import date, timedelta
@@ -924,9 +911,6 @@ with tabs[4]:
             st.success(f"Email sent to {recipient_email}!")
         except Exception as e:
             st.error(f"Email send failed: {e}")
-
-    if st.session_state.get("main_tabs") == tab_titles[4]:
-        st.session_state["active_tab"] = 4
 
 import textwrap
 
@@ -1176,8 +1160,6 @@ with tabs[5]:
         file_name=f"{file_prefix}.pdf",
         mime="application/pdf"
     )
-    if st.session_state.get("main_tabs") == tab_titles[5]:
-        st.session_state["active_tab"] = 5
 
 
 


### PR DESCRIPTION
## Summary
- Remove `key` argument from main tabs
- Drop obsolete `main_tabs` session state checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a431a89c83219fb7b106f8d243e0