### PR TITLE
Add completion certificate template and integrate into course completion flow

### DIFF
--- a/completion_letter_template.html
+++ b/completion_letter_template.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Course Completion - Learn Language Education Academy</title>
+</head>
+<body style="font-family: Arial, sans-serif; margin:0; padding:0; background-color:#ffffff;">
+  <div style="text-align:center; padding:20px;">
+    <img src="data:image/png;base64,{logo_base64}" alt="Learn Language Education Academy" style="max-width:150px;">
+  </div>
+  <div style="border:4px solid #000; padding:40px; margin:20px; text-align:center;">
+    <h2 style="margin-top:0;">Certificate of Completion</h2>
+    <p style="font-size:16px;">This certifies that <strong>{student_name}</strong> has successfully completed the <strong>{level}</strong> course on {completion_date}.</p>
+    <div style="margin-top:20px; text-align:left;">
+      {content}
+    </div>
+  </div>
+  <div style="font-size:12px;color:#555;text-align:center;padding:20px;background-color:#f7f7f7;">
+    <strong>{school_name}</strong><br/>
+    {school_address}<br/>
+    Phone: {school_phone}<br/>
+    <a href="{school_website}">{school_website}</a>
+  </div>
+</body>
+</html>

--- a/email.py
+++ b/email.py
@@ -11,7 +11,7 @@ import base64
 
 import pandas as pd
 import streamlit as st
-from fpdf import FPDF
+from fpdf import FPDF, HTMLMixin
 import qrcode
 from PIL import Image  # For logo image handling
 from io import BytesIO
@@ -201,6 +201,35 @@ def render_reminder_html(body_text: str) -> str:
     return template.format(
         logo_base64=logo_b64,
         content=body_text.replace("\n", "<br/>") if body_text else "",
+        school_name=SCHOOL_NAME,
+        school_address=SCHOOL_ADDRESS,
+        school_phone=SCHOOL_PHONE,
+        school_website=SCHOOL_WEBSITE,
+    )
+
+
+def render_completion_html(student_name: str, level: str, completion_date: date) -> str:
+    """Render the course completion letter using the certificate template."""
+    base_dir = os.path.dirname(__file__)
+    template_path = os.path.join(base_dir, "completion_letter_template.html")
+    logo_path = os.path.join(base_dir, "logo.png")
+    with open(logo_path, "rb") as lf:
+        logo_b64 = base64.b64encode(lf.read()).decode("utf-8")
+    with open(template_path, "r", encoding="utf-8") as tf:
+        template = tf.read()
+    default_message = (
+        f"Congratulations on finishing your {level} course, {student_name}! "
+        "You worked hard and made great progress.<br><br>"
+        "Please think about whether you want to prepare for the exam or move on to the next level. "
+        "I wish you continued success as you make your next decision!<br><br>"
+        f"Best wishes,<br>{TUTOR_NAME}<br>{TUTOR_TITLE}"
+    )
+    return template.format(
+        logo_base64=logo_b64,
+        student_name=student_name,
+        level=level,
+        completion_date=completion_date.strftime("%B %d, %Y"),
+        content=default_message,
         school_name=SCHOOL_NAME,
         school_address=SCHOOL_ADDRESS,
         school_phone=SCHOOL_PHONE,
@@ -872,82 +901,85 @@ with tabs[4]:
             f"Enrollment valid from {enrollment_start:%m/%d/%Y} to {enrollment_end:%m/%d/%Y}.<br><br>"
             f"Business Reg No: {BUSINESS_REG}.<br><br>"
         )
+        email_subject = st.text_input("Subject", value=f"{msg_type} - {student_name}", key="email_subject")
+        email_body = st.text_area("Email Body (HTML supported)", value=body_default, key="email_body", height=220)
+        st.markdown("**Preview Message:**")
+        st.markdown(email_body, unsafe_allow_html=True)
     else:  # Course Completion Letter
-        body_default = (
-            f"Congratulations on finishing your {student_level} course, {student_name}! "
-            "You worked hard and made great progress.<br><br>"
-            "Please think about whether you want to prepare for the exam or move on to the next level. "
-            "I wish you continued success as you make your next decision!<br><br>"
-            "Best wishes,<br>Felix Asadu<br>Director"
-        )
-
-    email_subject = st.text_input("Subject", value=f"{msg_type} - {student_name}", key="email_subject")
-    email_body    = st.text_area("Email Body (HTML supported)", value=body_default, key="email_body", height=220)
-
-    st.markdown("**Preview Message:**")
-    st.markdown(email_body, unsafe_allow_html=True)
+        completion_date = st.date_input("Completion Date", value=date.today(), key="completion_date")
+        body_default = render_completion_html(student_name, student_level, completion_date)
+        email_subject = st.text_input("Subject", value=f"{msg_type} - {student_name}", key="email_subject")
+        email_body = st.text_area("Email Body (HTML supported)", value=body_default, key="email_body", height=220)
+        st.markdown("**Preview Message:**")
+        st.components.v1.html(email_body, height=600)
 
     # ---- 5. Generate PDF Button (and preview) ----
     st.subheader("PDF Preview & Download")
 
-    class LetterPDF(FPDF):
-        def header(self):
-            if logo_file:
-                ext = logo_file.name.split('.')[-1]
-                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=f".{ext}")
-                tmp.write(logo_file.read()); tmp.close()
-                self.image(tmp.name, x=10, y=8, w=28)
-            self.set_font('Arial', 'B', 16)
-            self.cell(0, 9, safe_pdf(SCHOOL_NAME), ln=True, align='C')
-            self.set_font('Arial', '', 11)
-            self.cell(0, 7, safe_pdf(f"{SCHOOL_WEBSITE} | {SCHOOL_PHONE} | {SCHOOL_ADDRESS}"), ln=True, align='C')
-            self.set_font('Arial', 'I', 10)
-            self.cell(0, 7, safe_pdf(f"Business Reg No: {BUSINESS_REG}"), ln=True, align='C')
-            self.ln(3)
-            self.set_draw_color(200,200,200); self.set_line_width(0.5)
-            self.line(10, self.get_y(), 200, self.get_y()); self.ln(6)
-        def watermark(self):
-            if watermark_file_path:
-                self.image(watermark_file_path, x=38, y=60, w=130)
-        def footer(self):
-            qr = make_qr_code(SCHOOL_WEBSITE)
-            self.image(qr, x=180, y=275, w=18)
-            self.set_y(-18)
-            self.set_font('Arial', 'I', 8)
-            self.cell(0, 10, safe_pdf("Generated without signature."), 0, 0, 'C')
+    if msg_type == "Course Completion Letter":
+        class CompletionPDF(FPDF, HTMLMixin):
+            pass
+        pdf = CompletionPDF()
+        pdf.add_page()
+        pdf.write_html(email_body)
+        output_data = pdf.output(dest="S")
+        pdf_bytes = output_data if isinstance(output_data, bytes) else output_data.encode("latin-1", "replace")
+    else:
+        class LetterPDF(FPDF):
+            def header(self):
+                if logo_file:
+                    ext = logo_file.name.split('.')[-1]
+                    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=f".{ext}")
+                    tmp.write(logo_file.read()); tmp.close()
+                    self.image(tmp.name, x=10, y=8, w=28)
+                self.set_font('Arial', 'B', 16)
+                self.cell(0, 9, safe_pdf(SCHOOL_NAME), ln=True, align='C')
+                self.set_font('Arial', '', 11)
+                self.cell(0, 7, safe_pdf(f"{SCHOOL_WEBSITE} | {SCHOOL_PHONE} | {SCHOOL_ADDRESS}"), ln=True, align='C')
+                self.set_font('Arial', 'I', 10)
+                self.cell(0, 7, safe_pdf(f"Business Reg No: {BUSINESS_REG}"), ln=True, align='C')
+                self.ln(3)
+                self.set_draw_color(200,200,200); self.set_line_width(0.5)
+                self.line(10, self.get_y(), 200, self.get_y()); self.ln(6)
+            def watermark(self):
+                if watermark_file_path:
+                    self.image(watermark_file_path, x=38, y=60, w=130)
+            def footer(self):
+                qr = make_qr_code(SCHOOL_WEBSITE)
+                self.image(qr, x=180, y=275, w=18)
+                self.set_y(-18)
+                self.set_font('Arial', 'I', 8)
+                self.cell(0, 10, safe_pdf("Generated without signature."), 0, 0, 'C')
 
-    pdf = LetterPDF()
-    pdf.add_page()
-    pdf.watermark()
-    pdf.set_font("Arial", size=12)
-    import re
-    pdf.multi_cell(0, 8, safe_pdf(re.sub(r"<br\s*/?>", "\n", email_body)))
-    pdf.ln(6)
-    if msg_type == "Letter of Enrollment":
+        pdf = LetterPDF()
+        pdf.add_page()
+        pdf.watermark()
+        pdf.set_font("Arial", size=12)
+        import re
+        pdf.multi_cell(0, 8, safe_pdf(re.sub(r"<br\s*/?>", "\n", email_body)))
+        pdf.ln(6)
         pdf.set_font("Arial", size=11)
         pdf.cell(0, 8, safe_pdf("Yours sincerely,"), ln=True)
         pdf.cell(0, 7, safe_pdf("Felix Asadu"), ln=True)
         pdf.cell(0, 7, safe_pdf("Director"), ln=True)
         pdf.cell(0, 7, safe_pdf(SCHOOL_NAME), ln=True)
 
-    # --- Safe PDF bytes output (universal fallback) ---
-    output_data = pdf.output(dest="S")
-    if isinstance(output_data, bytes):
-        pdf_bytes = output_data
-    elif isinstance(output_data, str):
-        pdf_bytes = output_data.encode("latin-1", "replace")
-    else:
-        # fallback via temp file
-        tmpf = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.output(tmpf.name); tmpf.close()
-        with open(tmpf.name, "rb") as f: pdf_bytes = f.read()
-        os.remove(tmpf.name)
+        output_data = pdf.output(dest="S")
+        if isinstance(output_data, bytes):
+            pdf_bytes = output_data
+        elif isinstance(output_data, str):
+            pdf_bytes = output_data.encode("latin-1", "replace")
+        else:
+            tmpf = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+            pdf.output(tmpf.name); tmpf.close()
+            with open(tmpf.name, "rb") as f: pdf_bytes = f.read()
+            os.remove(tmpf.name)
 
     st.download_button(
         "📄 Download Letter/PDF",
         data=pdf_bytes,
         file_name=f"{student_name.replace(' ', '_')}_{msg_type.replace(' ','_')}.pdf",
-        mime="application/pdf"
+        mime="application/pdf",
     )
     st.caption("You can share this PDF on WhatsApp or by email.")
 


### PR DESCRIPTION
## Summary
- Add certificate-style HTML template for course completion letters.
- Render template with dynamic student fields for email previews and PDF generation.

## Testing
- `python -m py_compile email.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4abc5610c8321b0e7b878c59cd72d