### PR TITLE
Enable contract text wrapping in PDF receipts

### DIFF
--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,6 +1,8 @@
 # utils/pdf_utils.py
 
 from fpdf import FPDF
+from fpdf.enums import WrapMode
+from fpdf.errors import FPDFException
 from datetime import date, datetime, timedelta
 from utils import safe_pdf
 
@@ -68,8 +70,12 @@ def generate_receipt_and_contract_pdf(
     pdf.cell(200, 10, safe_pdf(f"{school_name} Student Contract"), ln=True, align="C")
     pdf.set_font("Arial", size=12)
     pdf.ln(10)
-    for line in filled.split("\n"):
-        pdf.multi_cell(0, 10, safe_pdf(line))
+    try:
+        pdf.multi_cell(0, 10, safe_pdf(filled), wrapmode=WrapMode.CHAR)
+    except FPDFException:
+        pdf.set_text_color(255, 0, 0)
+        pdf.multi_cell(0, 10, safe_pdf("Error: Unable to wrap contract text."))
+        pdf.set_text_color(0, 0, 0)
     pdf.ln(10)
     pdf.cell(0, 10, safe_pdf("Signed: Felix Asadu"), ln=True)
     pdf.set_y(-15)


### PR DESCRIPTION
## Summary
- Import `WrapMode` and `FPDFException` for advanced wrapping support
- Render contract text with `multi_cell` and character-level wrapping, falling back to user-visible error if wrapping fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b71446ec8321a4f6e02addaca7be