### PR TITLE
Handle bytes return from FPDF

### DIFF
--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -84,4 +84,9 @@ def generate_receipt_and_contract_pdf(
     pdf.cell(0, 10, safe_pdf(f"Generated on {now_str}"), align="C")
 
     # Return as bytes (for Streamlit or emailing)
-    return pdf.output(dest="S").encode('latin-1')
+    data = pdf.output(dest="S")
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, bytearray):
+        data = data.decode("latin-1")
+    return data.encode("latin-1")


### PR DESCRIPTION
## Summary
- Capture PDF output in a `data` variable before returning
- Return data directly when already bytes; otherwise encode using Latin-1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4cb7867dc8321ac28022779548bba