### PR TITLE
Handle mixed types from FPDF output

### DIFF
--- a/email.py
+++ b/email.py
@@ -1255,7 +1255,12 @@ with tabs[4]:
         pdf.add_page()
         pdf.write_html(email_body)
         output_data = pdf.output(dest="S")
-        pdf_bytes = output_data if isinstance(output_data, bytes) else output_data.encode("latin-1", "replace")
+        if isinstance(output_data, bytes):
+            pdf_bytes = output_data
+        elif isinstance(output_data, str):
+            pdf_bytes = output_data.encode("latin-1", "replace")
+        else:
+            pdf_bytes = bytes(output_data)
 
     elif msg_type == "Payment Confirmation":
         student_row_dict = {


### PR DESCRIPTION
## Summary
- Improve Course Completion Letter PDF generation to handle bytes, strings, and other iterable outputs.

## Testing
- `python - <<'PY'
import sys
sys.path.remove('')
from fpdf import FPDF, HTMLMixin
class CompletionPDF(FPDF, HTMLMixin):
    pass
pdf = CompletionPDF()
pdf.add_page()
pdf.set_font('Arial', size=12)
pdf.cell(40,10,'Hello')
output_data = pdf.output(dest='S')
print('type', type(output_data))
if isinstance(output_data, bytes):
    pdf_bytes = output_data
elif isinstance(output_data, str):
    pdf_bytes = output_data.encode('latin-1', 'replace')
else:
    pdf_bytes = bytes(output_data)
print('length', len(pdf_bytes))
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d12134308321a00e6051c1a1d87a