### PR TITLE
Remove logo from completion certificates

### DIFF
--- a/completion_letter_template.html
+++ b/completion_letter_template.html
@@ -5,9 +5,6 @@
 <title>Course Completion - Learn Language Education Academy</title>
 </head>
 <body style="font-family: Arial, sans-serif; margin:0; padding:0; background-color:#ffffff;">
-  <div style="text-align:center; padding:20px;">
-    <img src="data:image/png;base64,{logo_base64}" alt="Learn Language Education Academy" style="max-width:150px;">
-  </div>
   <div style="border:4px solid #000; padding:40px; margin:20px; text-align:center;">
     <h2 style="margin-top:0;">Certificate of Completion</h2>
     <p style="font-size:16px;">This certifies that <strong>{student_name}</strong> has successfully completed the <strong>{level}</strong> course on {completion_date}.</p>

--- a/email.py
+++ b/email.py
@@ -214,9 +214,6 @@ def render_completion_html(student_name: str, level: str, completion_date: date)
     """Render the course completion letter using the certificate template."""
     base_dir = os.path.dirname(__file__)
     template_path = os.path.join(base_dir, "completion_letter_template.html")
-    logo_path = os.path.join(base_dir, "logo.png")
-    with open(logo_path, "rb") as lf:
-        logo_b64 = base64.b64encode(lf.read()).decode("utf-8")
     with open(template_path, "r", encoding="utf-8") as tf:
         template = tf.read()
     default_message = (
@@ -227,7 +224,6 @@ def render_completion_html(student_name: str, level: str, completion_date: date)
         f"Best wishes,<br>{TUTOR_NAME}<br>{TUTOR_TITLE}"
     )
     return template.format(
-        logo_base64=logo_b64,
         student_name=student_name,
         level=level,
         completion_date=completion_date.strftime("%B %d, %Y"),


### PR DESCRIPTION
## Summary
- Remove logo `<img>` block from completion letter template
- Stop encoding and injecting logo when rendering completion certificates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5717c48848321ae097f69fbd8ab8e