### PR TITLE
Allow missing columns in col_lookup

### DIFF
--- a/email.py
+++ b/email.py
@@ -87,13 +87,13 @@ SENDER_EMAIL, SMTP_HOST, SMTP_PORT, SMTP_USE_TLS, SMTP_USERNAME, SMTP_PASSWORD =
 
 # ==== UNIVERSAL HELPERS ====
 
-def col_lookup(df: pd.DataFrame, name: str) -> str:
+def col_lookup(df: pd.DataFrame, name: str, default=None) -> str:
     """Find the actual column name for a logical key, case/space/underscore-insensitive."""
     key = name.lower().replace(" ", "").replace("_", "")
     for c in df.columns:
         if c.lower().replace(" ", "").replace("_", "") == key:
             return c
-    raise KeyError(f"Column '{name}' not found in DataFrame")
+    return default
 
 def make_qr_code(url):
     """Generate QR code image file for a given URL, return temp filename."""
@@ -378,14 +378,6 @@ with tabs[0]:
         df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
         return df
 
-    def col_lookup(df: pd.DataFrame, name: str) -> str:
-        """Case/space/underscore insensitive column resolver."""
-        key = name.lower().replace(" ", "").replace("_", "")
-        for c in df.columns:
-            if c.lower().replace(" ", "").replace("_", "") == key:
-                return c
-        return None
-
     def clean_phone_gh(phone):
         """Return Ghana phone as 233XXXXXXXXX or '' if invalid."""
         import re
@@ -517,7 +509,7 @@ with tabs[0]:
             "emergency_contact_phone_number", "emergency_contact",
             "status", "enrolldate", "classname"
         ]:
-            col_lookup_df[key] = col_lookup(df_pending, key)
+            col_lookup_df[key] = col_lookup(df_pending, key, default=None)
 
         # ---- Search / Filter
         search = st.text_input("🔎 Search any field (name, code, email, etc.)", "")

--- a/tests/test_col_lookup.py
+++ b/tests/test_col_lookup.py
@@ -1,0 +1,30 @@
+import ast
+import pathlib
+import pandas as pd
+
+
+def get_col_lookup():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_node = next(
+        node for node in module_ast.body if isinstance(node, ast.FunctionDef) and node.name == "col_lookup"
+    )
+    module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(module, filename="email.py", mode="exec")
+    ns = {"pd": pd}
+    exec(code, ns)
+    return ns["col_lookup"]
+
+col_lookup = get_col_lookup()
+
+
+def test_col_lookup_existing_column():
+    df = pd.DataFrame(columns=["Student Code", "Balance Due"])
+    assert col_lookup(df, "studentcode") == "Student Code"
+    assert col_lookup(df, "BALANCE_DUE") == "Balance Due"
+
+
+def test_col_lookup_missing_column_returns_default():
+    df = pd.DataFrame(columns=["A"])
+    assert col_lookup(df, "missing", default="fallback") == "fallback"
+    assert col_lookup(df, "another_missing") is None


### PR DESCRIPTION
## Summary
- Refactor global `col_lookup` to accept an optional `default` value instead of throwing `KeyError`
- Remove redundant local `col_lookup` in Pending tab and build column map with optional default
- Add unit tests for `col_lookup` covering existing and missing columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5a4cde3008321a5110e1b66e90ffa