### PR TITLE
Include ClassName in default pending student columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # email
+
+## Pending Students View
+
+When reviewing pending students, the app preselects a set of columns for quick viewing and editing. The default columns are:
+
+- Name
+- Phone
+- Email
+- Location
+- Level
+- Paid
+- Balance
+- ContractStart
+- ContractEnd
+- StudentCode
+- ClassName
+
+All default columns, including **ClassName**, can be edited directly in the interface.

--- a/email.py
+++ b/email.py
@@ -541,6 +541,7 @@ with tabs[0]:
             col_lookup_df.get("contractstart"),
             col_lookup_df.get("contractend"),
             col_lookup_df.get("studentcode"),
+            col_lookup_df.get("classname"),
         } if c]
         selected_cols = st.multiselect(
             "Show columns (for easy viewing):",


### PR DESCRIPTION
## Summary
- preselect `ClassName` column when showing pending students
- document default columns now including `ClassName`

## Testing
- `pytest -q`
- Verified default column list contains `ClassName`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4cb43f88321b24c5864f7424fb6