### PR TITLE
Support flexible enrollment date column names

### DIFF
--- a/email.py
+++ b/email.py
@@ -462,10 +462,13 @@ with tabs[0]:
 
         # Status & dates
         status = (src_row.get(col_lookup_df.get("status", ""), "") or "Active").strip()
-        enroll_date = parse_date_flex(
+
+        # Enrollment date column supports "EnrollDate" or "Enroll_Date" headers
+        raw_enroll = (
             src_row.get(col_lookup_df.get("enrolldate", ""), "")
-            or src_row.get(col_lookup_df.get("enrolldate", ""), "")
+            or src_row.get(col_lookup_df.get("enroll_date", ""), "")
         )
+        enroll_date = parse_date_flex(raw_enroll)
         if not enroll_date:
             enroll_date = date.today().isoformat()
 

--- a/tests/test_build_main_row.py
+++ b/tests/test_build_main_row.py
@@ -1,0 +1,39 @@
+import ast
+import pathlib
+from datetime import date
+
+import pandas as pd
+import pytest
+
+
+def load_namespace():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_nodes = [
+        node
+        for node in ast.walk(module_ast)
+        if isinstance(node, ast.FunctionDef) and node.name in {"parse_date_flex", "build_main_row"}
+    ]
+    mod = ast.Module(body=func_nodes, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, filename="email.py", mode="exec")
+    ns = {"pd": pd, "date": date}
+    exec(code, ns)
+    return ns
+
+
+@pytest.mark.parametrize("header", ["EnrollDate", "Enroll_Date"])
+def test_build_main_row_enroll_date_headers(header):
+    ns = load_namespace()
+    ns["clean_phone_gh"] = lambda x: x  # minimal stub
+    ns["TARGET_COLUMNS"] = ["EnrollDate"]
+
+    if header == "EnrollDate":
+        ns["col_lookup_df"] = {"enrolldate": "EnrollDate"}
+    else:
+        ns["col_lookup_df"] = {"enroll_date": "Enroll_Date"}
+
+    build_main_row = ns["build_main_row"]
+    src = {header: "2024-02-03"}
+    result = build_main_row(src)
+    assert result["EnrollDate"] == "2024-02-03"


### PR DESCRIPTION
## Summary
- handle both `EnrollDate` and `Enroll_Date` headers when building main sheet rows
- document supported enrollment date column names
- add tests for both enrollment date header styles

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4c6ef288321a9facc71ecbf5157