### PR TITLE
Handle non-string values in build_main_row

### DIFF
--- a/email.py
+++ b/email.py
@@ -378,6 +378,20 @@ with tabs[0]:
         df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
         return df
 
+    from typing import Any
+
+    def _safe_str(value: Any) -> str:
+        if value is None:
+            return ""
+        try:
+            if pd.isna(value):
+                return ""
+        except Exception:
+            pass
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return ""
+        return str(value)
+
     def col_lookup(df: pd.DataFrame, name: str) -> str:
         """Case/space/underscore insensitive column resolver."""
         key = name.lower().replace(" ", "").replace("_", "")
@@ -416,10 +430,10 @@ with tabs[0]:
         Map a single pending row -> main sheet shape.
         Omits: Filter Rows to Merge, Daily_Limit, Uses_Today, Last_Date.
         """
-        name = src_row.get(col_lookup_df.get("name", ""), "").strip()
+        name = _safe_str(src_row.get(col_lookup_df.get("name", ""), "")).strip()
         phone_raw = src_row.get(col_lookup_df.get("phone", ""), "")
         phone = clean_phone_gh(phone_raw)
-        location = src_row.get(col_lookup_df.get("location", ""), "").strip()
+        location = _safe_str(src_row.get(col_lookup_df.get("location", ""), "")).strip()
         level = (src_row.get(col_lookup_df.get("level", ""), "") or "").upper().strip()
 
         paid = src_row.get(col_lookup_df.get("paid", ""), "")
@@ -448,8 +462,8 @@ with tabs[0]:
             except Exception:
                 ce_iso = ""
 
-        email = src_row.get(col_lookup_df.get("email", ""), "").strip()
-        student_code = src_row.get(col_lookup_df.get("studentcode", ""), "").strip()
+        email = _safe_str(src_row.get(col_lookup_df.get("email", ""), "")).strip()
+        student_code = _safe_str(src_row.get(col_lookup_df.get("studentcode", ""), "")).strip()
 
         # Emergency contact: try a few candidates from the pending sheet
         ec_key = (
@@ -461,7 +475,7 @@ with tabs[0]:
         emergency_phone = clean_phone_gh(src_row.get(ec_key, "")) if ec_key else ""
 
         # Status & dates
-        status = (src_row.get(col_lookup_df.get("status", ""), "") or "Active").strip()
+        status = _safe_str(src_row.get(col_lookup_df.get("status", ""), "")).strip() or "Active"
         enroll_date = parse_date_flex(
             src_row.get(col_lookup_df.get("enrolldate", ""), "")
             or src_row.get(col_lookup_df.get("enrolldate", ""), "")
@@ -470,7 +484,8 @@ with tabs[0]:
             enroll_date = date.today().isoformat()
 
         # ClassName fallback
-        class_name = (src_row.get(col_lookup_df.get("classname", ""), "") or level).strip()
+        class_name = _safe_str(src_row.get(col_lookup_df.get("classname", ""), "")).strip()
+        class_name = class_name or level
 
         row = {
             "Name": name,

--- a/tests/test_build_main_row.py
+++ b/tests/test_build_main_row.py
@@ -1,0 +1,68 @@
+import ast
+from pathlib import Path
+from datetime import date
+
+import pandas as pd
+import pytest
+
+
+def get_build_main_row():
+    source = (Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    funcs = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            if node.name in {"_safe_str", "build_main_row"}:
+                funcs.append(node)
+            self.generic_visit(node)
+
+    Visitor().visit(module_ast)
+    module = ast.Module(body=funcs, type_ignores=[])
+    ns = {
+        "pd": pd,
+        "clean_phone_gh": lambda x: x,
+        "parse_date_flex": lambda x: x,
+        "date": date,
+        "Any": __import__("typing").Any,
+        "TARGET_COLUMNS": [
+            "Name", "Phone", "Location", "Level", "Paid", "Balance",
+            "ContractStart", "ContractEnd", "StudentCode", "Email",
+            "Emergency Contact (Phone Number)", "Status", "EnrollDate",
+            "ClassName",
+        ],
+        "col_lookup_df": {},
+    }
+    exec(compile(module, filename="email.py", mode="exec"), ns)
+    return ns["build_main_row"], ns
+
+
+build_main_row, ns = get_build_main_row()
+
+
+@pytest.mark.parametrize("bad_value", [None, float("nan"), 123])
+def test_build_main_row_non_string_inputs(bad_value):
+    src_row = {
+        "name": bad_value,
+        "location": bad_value,
+        "email": bad_value,
+        "studentcode": bad_value,
+        "status": bad_value,
+        "classname": bad_value,
+        "phone": "0241234567",
+        "level": "b2",
+        "paid": "",
+        "balance": "",
+        "contractstart": "2024-01-01",
+        "contractend": "",
+        "enrolldate": "",
+    }
+    ns["col_lookup_df"] = {k: k for k in src_row}
+    row = build_main_row(src_row)
+
+    assert row["Name"] == ""
+    assert row["Location"] == ""
+    assert row["Email"] == ""
+    assert row["StudentCode"] == ""
+    assert row["Status"] == "Active"
+    assert row["ClassName"] == "B2"


### PR DESCRIPTION
## Summary
- add `_safe_str` helper to sanitize non-string inputs
- use `_safe_str` for name, location, email, student code, status and class name
- test `build_main_row` handles `None`, `NaN`, and numeric values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4c51e508321a262a1c4bb89f27e