### PR TITLE
Remove unnecessary global in Pending Students refresh

### DIFF
--- a/email.py
+++ b/email.py
@@ -623,7 +623,6 @@ with tabs[0]:
 
                         # Refresh main student list and offer navigation
                         load_students.clear()
-                        global df_students
                         df_students = load_students()
                         if st.button("👀 View in All Students"):
                             st.session_state["active_tab"] = 1


### PR DESCRIPTION
## Summary
- Remove obsolete `global df_students` in Pending Students transfer refresh logic
- Refresh main student DataFrame cleanly after transferring rows

## Testing
- `python -m py_compile email.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b2aafb888321882e957cde7cfab6