### PR TITLE
Normalize date columns for pending student editor

### DIFF
--- a/email.py
+++ b/email.py
@@ -559,6 +559,14 @@ with tabs[0]:
                    for r in view_df.to_dict(orient="records")]
 
     edit_df = pd.DataFrame(mapped_rows, columns=TARGET_COLUMNS)
+
+    for col in ["ContractStart", "ContractEnd", "EnrollDate"]:
+        edit_df[col] = pd.to_datetime(edit_df[col], errors="coerce")
+    edit_df["EnrollDate"].fillna(pd.Timestamp.today().normalize(), inplace=True)
+
+    if not all(pd.api.types.is_datetime64_ns_dtype(edit_df[col]) for col in ["ContractStart", "ContractEnd", "EnrollDate"]):
+        raise TypeError("Date columns must be datetime64[ns]")
+
     # Add a selection column for sending
     edit_df.insert(0, "Select", True)
 


### PR DESCRIPTION
## Summary
- Normalize ContractStart, ContractEnd, and EnrollDate columns to `datetime64[ns]`
- Default missing EnrollDate values to today's date and enforce datetime dtypes

## Testing
- `pytest -q` *(fails: KeyError: 'build_main_row')*

------
https://chatgpt.com/codex/tasks/task_e_68b5c30015e4832195b0217920abd4df