### PR TITLE
Clarify CSV download button for selected rows

### DIFF
--- a/email.py
+++ b/email.py
@@ -664,8 +664,9 @@ with tabs[0]:
     with left:
         send_btn = st.button("🚚 Send selected to Main Sheet", type="primary", disabled=(len(to_send) == 0))
     with right:
+        st.caption("Only rows marked with the 'Select' checkbox are included in the download.")
         st.download_button(
-            "⬇️ Download edited CSV",
+            "⬇️ Download selected rows as CSV",
             pd.DataFrame(to_send)[TARGET_COLUMNS].to_csv(index=False),
             file_name="pending_to_send.csv"
         )


### PR DESCRIPTION
## Summary
- Rename edited CSV download button to “⬇️ Download selected rows as CSV”
- Add caption clarifying that only rows with the “Select” checkbox are included

## Testing
- `pytest -q` *(fails: KeyError: 'build_main_row')*

------
https://chatgpt.com/codex/tasks/task_e_68b5cda75648832181712f40a243a4b8