### PR TITLE
Add CSV download for pending entries table

### DIFF
--- a/email.py
+++ b/email.py
@@ -552,6 +552,12 @@ with tabs[0]:
     st.caption(f"Showing {len(view_df)} of {len(df_pending)} pending rows.")
     with st.expander("Show raw pending rows", expanded=False):
         st.dataframe(view_df, use_container_width=True, height=320)
+        st.download_button(
+            "Download CSV",
+            view_df.to_csv(index=False).encode("utf-8"),
+            file_name="pending_raw.csv",
+            mime="text/csv",
+        )
 
     # ---------- Build editable TARGET table ----------
     st.markdown("### 2️⃣ Edit student info (normalized to main sheet columns)")


### PR DESCRIPTION
## Summary
- Add Streamlit download button to export raw pending table as CSV

## Testing
- `pytest -q` *(fails: KeyError: 'build_main_row')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ce1cc448832182ae01541166cbf9