### PR TITLE
Ensure download export retains columns and disables empty downloads

### DIFF
--- a/email.py
+++ b/email.py
@@ -764,8 +764,9 @@ with tabs[0]:
     with right:
         st.download_button(
             "⬇️ Download edited CSV",
-            pd.DataFrame(to_send)[TARGET_COLUMNS].to_csv(index=False),
-            file_name="pending_to_send.csv"
+            pd.DataFrame(to_send, columns=TARGET_COLUMNS).to_csv(index=False),
+            file_name="pending_to_send.csv",
+            disabled=(len(to_send) == 0),
         )
 
     if send_btn:


### PR DESCRIPTION
## Summary
- Preserve CSV column order when exporting edited rows even if empty
- Disable download button when there are no rows to export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5dedcf3dc832186fc62f97cdb0cbb