### PR TITLE
Add Streamlit to-do page with Firestore persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 ## About Us Page
 
 The application provides an **About Us** tab that stores key contact and social media information for the team. Links can be viewed in the app or downloaded as a CSV for quick reference.
+
+## Weekly Team Tasks
+
+Run `streamlit run todo.py` to manage weekly team tasks.
+
+The page lets you:
+
+- Add tasks with a description, assignee, and due week.
+- Mark tasks complete from an interactive checklist.
+
+Tasks persist in Firestore under the `tasks` collection with fields `description`, `assignee`, `week` (ISO date), and `completed`. Configure `st.secrets["firebase"]` for database access. If SMTP details are provided in `st.secrets`, assignees receive email notifications when tasks are created or updated.

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,99 @@
+import streamlit as st
+from datetime import date
+import firebase_admin
+from firebase_admin import credentials, firestore
+import smtplib
+
+_db = None
+
+def _get_db():
+    global _db
+    if _db is None:
+        if not firebase_admin._apps:
+            cred = credentials.Certificate(dict(st.secrets["firebase"]))
+            firebase_admin.initialize_app(cred)
+        _db = firestore.client()
+    return _db
+
+def add_task(description: str, assignee: str, week: str):
+    db = _get_db()
+    db.collection("tasks").add(
+        {
+            "description": description,
+            "assignee": assignee,
+            "week": week,
+            "completed": False,
+        }
+    )
+
+def load_tasks(week: str):
+    db = _get_db()
+    docs = db.collection("tasks").where("week", "==", week).stream()
+    tasks = []
+    for doc in docs:
+        data = doc.to_dict() or {}
+        data["id"] = doc.id
+        tasks.append(data)
+    return tasks
+
+def update_task(task_id: str, updates: dict):
+    db = _get_db()
+    db.collection("tasks").document(task_id).update(updates)
+
+def notify_assignee(email: str, subject: str, body: str):
+    try:
+        smtp_conf = st.secrets.get("smtp", {})
+        sender = st.secrets.get("email_sender")
+        host = smtp_conf.get("host")
+        port = smtp_conf.get("port")
+        username = smtp_conf.get("username")
+        password = smtp_conf.get("password")
+        if not all([sender, host, port, email]):
+            return
+        msg = f"Subject: {subject}\n\n{body}"
+        with smtplib.SMTP(host, port) as server:
+            if smtp_conf.get("use_tls", True):
+                server.starttls()
+            if username and password:
+                server.login(username, password)
+            server.sendmail(sender, [email], msg)
+    except Exception as exc:
+        st.warning(f"Notification failed: {exc}")
+
+st.title("📝 Weekly Team Tasks")
+
+selected_week = st.date_input("Select week", value=date.today())
+
+with st.form("task_form", clear_on_submit=True):
+    desc = st.text_input("Task description")
+    assignee = st.text_input("Assignee")
+    due = st.date_input("Due date/Week", value=selected_week)
+    notify = st.checkbox("Email assignee", value=False)
+    submitted = st.form_submit_button("Add task")
+
+if submitted and desc and assignee:
+    week_str = due.isoformat()
+    add_task(desc, assignee, week_str)
+    if notify:
+        notify_assignee(
+            assignee,
+            "New task assigned",
+            f"'{desc}' due {week_str}",
+        )
+    st.success("Task added!")
+
+st.subheader(f"Tasks for {selected_week.isoformat()}")
+for task in load_tasks(selected_week.isoformat()):
+    checked = st.checkbox(
+        f"{task['description']} - {task['assignee']} (due {task['week']})",
+        value=task.get("completed", False),
+        key=task["id"],
+    )
+    if checked != task.get("completed", False):
+        update_task(task["id"], {"completed": checked})
+        notify_assignee(
+            task["assignee"],
+            "Task updated",
+            f"'{task['description']}' marked {'complete' if checked else 'incomplete'}",
+        )
+


### PR DESCRIPTION
## Summary
- add Streamlit to-do page with Firestore-backed task management and email notifications
- document usage and data storage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c07c018078832191cb315ee7a422e1