### PR TITLE
feat: add Social Templates page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Tasks persist in Firestore under the `tasks` collection with fields `description
 
 ## Social Media Templates
 
-Run `streamlit run social_templates.py` to manage reusable social media templates.
+Launch the app with `streamlit run email.py` and open the **Social Templates** page to manage reusable social media templates.
 
 The page lets you:
 

--- a/pages/social_templates.py
+++ b/pages/social_templates.py
@@ -1,0 +1,33 @@
+import streamlit as st
+import pandas as pd
+
+from social_templates import add_template, load_templates, delete_template
+
+st.title("\U0001F4E3 Social Media Templates")
+
+with st.form("template_form", clear_on_submit=True):
+    title = st.text_input("Title")
+    platform = st.text_input("Platform")
+    content = st.text_area("Template")
+    submitted = st.form_submit_button("Save template")
+
+if submitted and title and platform and content:
+    add_template(title, platform, content)
+    st.success("Template saved!")
+
+templates = load_templates()
+if templates:
+    df = pd.DataFrame(templates).drop(columns=["id"]) if templates else pd.DataFrame()
+    st.dataframe(df)
+    for tmpl in templates:
+        col1, col2, col3 = st.columns([3, 2, 1])
+        with col1:
+            st.write(f"**{tmpl['title']}** ({tmpl['platform']})")
+        with col2:
+            st.write(tmpl["content"])
+        with col3:
+            if st.button("Delete", key=f"del_{tmpl['id']}"):
+                delete_template(tmpl["id"])
+                st.experimental_rerun()
+else:
+    st.info("No templates yet.")

--- a/social_templates.py
+++ b/social_templates.py
@@ -1,9 +1,9 @@
 import streamlit as st
 import firebase_admin
 from firebase_admin import credentials, firestore
-import pandas as pd
 
 _db = None
+
 
 def _get_db():
     """Initialize and cache the Firestore client."""
@@ -15,12 +15,14 @@ def _get_db():
         _db = firestore.client()
     return _db
 
+
 def add_template(title: str, platform: str, content: str):
     """Add a new social media template to Firestore."""
     db = _get_db()
     db.collection("templates").add(
         {"title": title, "platform": platform, "content": content}
     )
+
 
 def load_templates():
     """Return all templates stored in Firestore."""
@@ -33,36 +35,15 @@ def load_templates():
         templates.append(data)
     return templates
 
+
 def delete_template(template_id: str):
     """Delete a template by document id."""
     db = _get_db()
     db.collection("templates").document(template_id).delete()
 
-st.title("\U0001F4E3 Social Media Templates")
 
-with st.form("template_form", clear_on_submit=True):
-    title = st.text_input("Title")
-    platform = st.text_input("Platform")
-    content = st.text_area("Template")
-    submitted = st.form_submit_button("Save template")
-
-if submitted and title and platform and content:
-    add_template(title, platform, content)
-    st.success("Template saved!")
-
-templates = load_templates()
-if templates:
-    df = pd.DataFrame(templates).drop(columns=["id"]) if templates else pd.DataFrame()
-    st.dataframe(df)
-    for tmpl in templates:
-        col1, col2, col3 = st.columns([3, 2, 1])
-        with col1:
-            st.write(f"**{tmpl['title']}** ({tmpl['platform']})")
-        with col2:
-            st.write(tmpl["content"])
-        with col3:
-            if st.button("Delete", key=f"del_{tmpl['id']}"):
-                delete_template(tmpl["id"])
-                st.experimental_rerun()
-else:
-    st.info("No templates yet.")
+if __name__ == "__main__":
+    st.title("\U0001F4E3 Social Media Templates")
+    st.info(
+        "This module now serves as a helper. Run `streamlit run email.py` and open the 'Social Templates' page."
+    )


### PR DESCRIPTION
## Summary
- move social template UI into `pages/social_templates.py`
- convert `social_templates.py` into shared helpers with deprecation notice
- document new multipage launch in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c07f6b6a508321a606035e56078186