### PR TITLE
Integrate Weekly Tasks tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The application provides an **About Us** tab that stores key contact and social 
 
 ## Weekly Team Tasks
 
-Run `streamlit run todo.py` to manage weekly team tasks.
+Launch the main app with `streamlit run email.py` and open the **📝 Weekly Tasks** tab to manage weekly team tasks.
 
 The page lets you:
 


### PR DESCRIPTION
## Summary
- Add "📝 Weekly Tasks" sidebar option to navigate to to-do tasks from main app
- Render weekly task management UI in new tab leveraging existing `todo` helpers
- Update documentation to point users to the new tab instead of a separate `todo.py` script

## Testing
- `python -m py_compile email.py todo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c082d937708321b3be713eb6cd301d