### PR TITLE
Normalize task week to start of week and keep due date

### DIFF
--- a/email.py
+++ b/email.py
@@ -1686,29 +1686,32 @@ elif selected_tab == tab_titles[8]:
     st.title("📝 Weekly Tasks")
 
     selected_week = st.date_input("Select week", value=date.today())
+    selected_week_start = selected_week - timedelta(days=selected_week.weekday())
 
     with st.form("task_form", clear_on_submit=True):
         desc = st.text_input("Task description")
         assignee = st.text_input("Assignee")
-        due = st.date_input("Due date/Week", value=selected_week)
+        due = st.date_input("Due date", value=selected_week)
         notify = st.checkbox("Email assignee", value=False)
         submitted = st.form_submit_button("Add task")
 
     if submitted and desc and assignee:
-        week_str = due.isoformat()
-        add_task(desc, assignee, week_str)
+        week_start = due - timedelta(days=due.weekday())
+        week_str = week_start.isoformat()
+        due_str = due.isoformat()
+        add_task(desc, assignee, week_str, due_str)
         if notify:
             notify_assignee(
                 assignee,
                 "New task assigned",
-                f"'{desc}' due {week_str}",
+                f"'{desc}' due {due_str}",
             )
         st.success("Task added!")
 
-    st.subheader(f"Tasks for {selected_week.isoformat()}")
-    for task in load_tasks(selected_week.isoformat()):
+    st.subheader(f"Tasks for week of {selected_week_start.isoformat()}")
+    for task in load_tasks(selected_week_start.isoformat()):
         checked = st.checkbox(
-            f"{task['description']} - {task['assignee']} (due {task['week']})",
+            f"{task['description']} - {task['assignee']} (due {task.get('due', task['week'])})",
             value=task.get("completed", False),
             key=task["id"],
         )


### PR DESCRIPTION
## Summary
- Normalize tasks to use week starting date for storage and retrieval
- Preserve the original due date and show it separately in the UI
- Apply week normalization when adding and listing tasks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0852aed84832188cf1e1751d18b47