### PR TITLE
Refactor social templates UI

### DIFF
--- a/pages/social_templates.py
+++ b/pages/social_templates.py
@@ -5,29 +5,33 @@ from social_templates import add_template, load_templates, delete_template
 
 st.title("\U0001F4E3 Social Media Templates")
 
-with st.form("template_form", clear_on_submit=True):
-    title = st.text_input("Title")
-    platform = st.text_input("Platform")
-    content = st.text_area("Template")
-    submitted = st.form_submit_button("Save template")
+with st.sidebar:
+    with st.form("template_form", clear_on_submit=True):
+        title = st.text_input("Title")
+        platform = st.text_input("Platform")
+        content = st.text_area("Template")
+        submitted = st.form_submit_button("Save template")
 
 if submitted and title and platform and content:
     add_template(title, platform, content)
-    st.success("Template saved!")
+    st.experimental_rerun()
 
 templates = load_templates()
 if templates:
-    df = pd.DataFrame(templates).drop(columns=["id"]) if templates else pd.DataFrame()
-    st.dataframe(df)
-    for tmpl in templates:
-        col1, col2, col3 = st.columns([3, 2, 1])
-        with col1:
-            st.write(f"**{tmpl['title']}** ({tmpl['platform']})")
-        with col2:
-            st.write(tmpl["content"])
-        with col3:
-            if st.button("Delete", key=f"del_{tmpl['id']}"):
-                delete_template(tmpl["id"])
-                st.experimental_rerun()
+    df = pd.DataFrame(templates)
+    df["delete"] = False
+    edited = st.data_editor(
+        df,
+        column_config={
+            "delete": st.column_config.CheckboxColumn("Delete", default=False),
+            "id": None,
+        },
+        hide_index=True,
+    )
+    to_delete = edited.loc[edited["delete"], "id"].tolist()
+    if to_delete:
+        for template_id in to_delete:
+            delete_template(template_id)
+        st.experimental_rerun()
 else:
     st.info("No templates yet.")


### PR DESCRIPTION
## Summary
- Replace dual template listing with a single `st.data_editor` featuring per-row delete checkboxes
- Move template creation form to the sidebar
- Refresh the page after saving or deleting templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0866e048c8321a6c46af21fa7a828