### PR TITLE
refactor: isolate todo UI

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -61,43 +61,48 @@ def notify_assignee(email: str, subject: str, body: str):
     except Exception as exc:
         st.warning(f"Notification failed: {exc}")
 
-st.title("📝 Weekly Team Tasks")
+def main():
+    st.title("📝 Weekly Team Tasks")
 
-selected_week = st.date_input("Select week", value=date.today())
-selected_week_start = selected_week - timedelta(days=selected_week.weekday())
+    selected_week = st.date_input("Select week", value=date.today())
+    selected_week_start = selected_week - timedelta(days=selected_week.weekday())
 
-with st.form("task_form", clear_on_submit=True):
-    desc = st.text_input("Task description")
-    assignee = st.text_input("Assignee")
-    due = st.date_input("Due date", value=selected_week)
-    notify = st.checkbox("Email assignee", value=False)
-    submitted = st.form_submit_button("Add task")
+    with st.form("task_form", clear_on_submit=True):
+        desc = st.text_input("Task description")
+        assignee = st.text_input("Assignee")
+        due = st.date_input("Due date", value=selected_week)
+        notify = st.checkbox("Email assignee", value=False)
+        submitted = st.form_submit_button("Add task")
 
-if submitted and desc and assignee:
-    week_start = due - timedelta(days=due.weekday())
-    week_str = week_start.isoformat()
-    due_str = due.isoformat()
-    add_task(desc, assignee, week_str, due_str)
-    if notify:
-        notify_assignee(
-            assignee,
-            "New task assigned",
-            f"'{desc}' due {due_str}",
+    if submitted and desc and assignee:
+        week_start = due - timedelta(days=due.weekday())
+        week_str = week_start.isoformat()
+        due_str = due.isoformat()
+        add_task(desc, assignee, week_str, due_str)
+        if notify:
+            notify_assignee(
+                assignee,
+                "New task assigned",
+                f"'{desc}' due {due_str}",
+            )
+        st.success("Task added!")
+
+    st.subheader(f"Tasks for week of {selected_week_start.isoformat()}")
+    for task in load_tasks(selected_week_start.isoformat()):
+        checked = st.checkbox(
+            f"{task['description']} - {task['assignee']} (due {task.get('due', task['week'])})",
+            value=task.get("completed", False),
+            key=task["id"],
         )
-    st.success("Task added!")
+        if checked != task.get("completed", False):
+            update_task(task["id"], {"completed": checked})
+            notify_assignee(
+                task["assignee"],
+                "Task updated",
+                f"'{task['description']}' marked {'complete' if checked else 'incomplete'}",
+            )
 
-st.subheader(f"Tasks for week of {selected_week_start.isoformat()}")
-for task in load_tasks(selected_week_start.isoformat()):
-    checked = st.checkbox(
-        f"{task['description']} - {task['assignee']} (due {task.get('due', task['week'])})",
-        value=task.get("completed", False),
-        key=task["id"],
-    )
-    if checked != task.get("completed", False):
-        update_task(task["id"], {"completed": checked})
-        notify_assignee(
-            task["assignee"],
-            "Task updated",
-            f"'{task['description']}' marked {'complete' if checked else 'incomplete'}",
-        )
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- move todo UI logic into a main() function
- guard execution with if __name__ == "__main__": main()

## Testing
- `python - <<'PY'
import sys
if '' in sys.path:
    sys.path.remove('')
import pytest
raise SystemExit(pytest.main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c08b324c688321b72643cc47d922fb