### PR TITLE
Add refresh button for leaderboard data

### DIFF
--- a/email.py
+++ b/email.py
@@ -1476,6 +1476,13 @@ elif selected_tab == tab_titles[6]:
             df["date"] = pd.to_datetime(df["date"], errors="coerce")
         return df
 
+    if st.button("🔄 Refresh data"):
+        load_assignment_scores.clear()
+        if hasattr(st, "rerun"):
+            st.rerun()
+        else:  # pragma: no cover - fallback for older Streamlit
+            st.experimental_rerun()
+
     df_scores = load_assignment_scores()
     if df_scores is None or df_scores.empty:
         st.info("No assignment score data available.")


### PR DESCRIPTION
## Summary
- allow leaderboard data to be refreshed on demand

## Testing
- `python - <<'PY'
import sys
sys.path = [p for p in sys.path if p != '' and p != '/workspace/email']
import pytest
raise SystemExit(pytest.main(['-q']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c1a6b6dc18832188678e34f258ac33