### PR TITLE
Cache Firestore task and template reads

### DIFF
--- a/social_templates.py
+++ b/social_templates.py
@@ -22,8 +22,10 @@ def add_template(title: str, platform: str, content: str):
     db.collection("templates").add(
         {"title": title, "platform": platform, "content": content}
     )
+    load_templates.clear()
 
 
+@st.cache_data(ttl=60)
 def load_templates():
     """Return all templates stored in Firestore."""
     db = _get_db()
@@ -40,6 +42,7 @@ def delete_template(template_id: str):
     """Delete a template by document id."""
     db = _get_db()
     db.collection("templates").document(template_id).delete()
+    load_templates.clear()
 
 
 if __name__ == "__main__":

--- a/tests/test_task_template_cache.py
+++ b/tests/test_task_template_cache.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path for module imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import todo
+import social_templates
+
+
+def _doc(data, doc_id="id"):
+    d = MagicMock()
+    d.to_dict.return_value = data
+    d.id = doc_id
+    return d
+
+
+def test_load_tasks_cache_and_clears_on_add():
+    todo.load_tasks.clear()
+    db = MagicMock()
+    coll = db.collection.return_value
+    where = coll.where.return_value
+    where.stream.return_value = [_doc({"description": "t1", "assignee": "a1", "week": "w1"}, "id1")]
+    with patch("todo._get_db", return_value=db):
+        first = todo.load_tasks("w1")
+        second = todo.load_tasks("w1")
+        assert first == second
+        assert where.stream.call_count == 1
+
+        where.stream.return_value = [_doc({"description": "t2", "assignee": "a2", "week": "w1"}, "id2")]
+        todo.add_task("t2", "a2", "w1", "d")
+        refreshed = todo.load_tasks("w1")
+    assert refreshed == [{"description": "t2", "assignee": "a2", "week": "w1", "id": "id2"}]
+
+
+def test_update_task_clears_cache():
+    with patch("todo._get_db") as get_db, patch.object(todo.load_tasks, "clear") as mock_clear:
+        doc_ref = MagicMock()
+        get_db.return_value.collection.return_value.document.return_value = doc_ref
+        todo.update_task("id1", {"completed": True})
+        doc_ref.update.assert_called_once_with({"completed": True})
+        mock_clear.assert_called_once()
+
+
+def test_load_templates_cache_and_clears_on_add():
+    social_templates.load_templates.clear()
+    db = MagicMock()
+    coll = db.collection.return_value
+    coll.stream.return_value = [_doc({"title": "tmp1", "platform": "p1", "content": "c1"}, "id1")]
+    with patch("social_templates._get_db", return_value=db):
+        first = social_templates.load_templates()
+        second = social_templates.load_templates()
+        assert first == second
+        assert coll.stream.call_count == 1
+
+        coll.stream.return_value = [_doc({"title": "tmp2", "platform": "p2", "content": "c2"}, "id2")]
+        social_templates.add_template("tmp2", "p2", "c2")
+        refreshed = social_templates.load_templates()
+    assert refreshed == [{"title": "tmp2", "platform": "p2", "content": "c2", "id": "id2"}]
+
+
+def test_delete_template_clears_cache():
+    with patch("social_templates._get_db") as get_db, patch.object(social_templates.load_templates, "clear") as mock_clear:
+        doc_ref = MagicMock()
+        get_db.return_value.collection.return_value.document.return_value = doc_ref
+        social_templates.delete_template("id1")
+        doc_ref.delete.assert_called_once()
+        mock_clear.assert_called_once()

--- a/todo.py
+++ b/todo.py
@@ -26,7 +26,9 @@ def add_task(description: str, assignee: str, week: str, due: str | None = None)
             "completed": False,
         }
     )
+    load_tasks.clear()
 
+@st.cache_data(ttl=60)
 def load_tasks(week: str):
     db = _get_db()
     docs = db.collection("tasks").where("week", "==", week).stream()
@@ -40,6 +42,7 @@ def load_tasks(week: str):
 def update_task(task_id: str, updates: dict):
     db = _get_db()
     db.collection("tasks").document(task_id).update(updates)
+    load_tasks.clear()
 
 def notify_assignee(email: str, subject: str, body: str):
     try:


### PR DESCRIPTION
## Summary
- cache Firestore-backed task and template loaders for 60 seconds
- clear caches after add/update/delete operations
- test caching and cache clearing behavior for tasks and templates

## Testing
- `pytest tests/test_task_template_cache.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c6b4e1cc8321a4e92af3790adc3c