### PR TITLE
Limit Firestore query fields

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,12 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "week", "order": "ASCENDING"}
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /tasks/{taskId} {
+      allow read: if request.query.selectFields.hasOnly(['description','assignee','week','due','completed']);
+      allow write: if true;
+    }
+    match /templates/{templateId} {
+      allow read: if request.query.selectFields.hasOnly(['title','platform','content']);
+      allow write: if true;
+    }
+  }
+}

--- a/social_templates.py
+++ b/social_templates.py
@@ -29,7 +29,11 @@ def add_template(title: str, platform: str, content: str):
 def load_templates():
     """Return all templates stored in Firestore."""
     db = _get_db()
-    docs = db.collection("templates").stream()
+    docs = (
+        db.collection("templates")
+        .select(["title", "platform", "content"])
+        .stream()
+    )
     templates = []
     for doc in docs:
         data = doc.to_dict() or {}

--- a/todo.py
+++ b/todo.py
@@ -31,7 +31,12 @@ def add_task(description: str, assignee: str, week: str, due: str | None = None)
 @st.cache_data(ttl=60)
 def load_tasks(week: str):
     db = _get_db()
-    docs = db.collection("tasks").where("week", "==", week).stream()
+    docs = (
+        db.collection("tasks")
+        .where("week", "==", week)
+        .select(["description", "assignee", "week", "due", "completed"])
+        .stream()
+    )
     tasks = []
     for doc in docs:
         data = doc.to_dict() or {}


### PR DESCRIPTION
## Summary
- Restrict Firestore task queries to description, assignee, week, due and completed fields
- Limit template queries to title, platform and content
- Add Firestore security rules and index definitions for field-restricted reads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2c9bc377c83219d76591b9b6fae33