### PR TITLE
Switch to st.rerun for Streamlit refreshes

### DIFF
--- a/email.py
+++ b/email.py
@@ -427,7 +427,7 @@ if "tabs_loaded" not in st.session_state:
 if st.button("Refresh data"):
     load_students.clear()
     load_ref_answers.clear()
-    st.experimental_rerun()
+    st.rerun()
 
 # ==== LOAD MAIN DATAFRAMES ONCE ====
 if os.getenv("EMAIL_SKIP_PRELOAD") == "1":

--- a/social_templates.py
+++ b/social_templates.py
@@ -39,7 +39,7 @@ def load_templates():
                 data["id"] = doc.id
                 templates.append(data)
             state["templates"] = templates
-            st.experimental_rerun()
+            st.rerun()
 
         state["template_listener"] = query.on_snapshot(on_snapshot)
 

--- a/tests/test_firestore_listeners.py
+++ b/tests/test_firestore_listeners.py
@@ -32,7 +32,7 @@ def test_load_tasks_snapshot_updates_state_and_reruns():
 
     query.on_snapshot.side_effect = on_snapshot
     with patch("todo._get_db", return_value=db), patch(
-        "streamlit.experimental_rerun", create=True
+        "streamlit.rerun", create=True
     ) as rerun:
         assert todo.load_tasks("w1") == []
         callback_holder["cb"](
@@ -74,7 +74,7 @@ def test_load_tasks_replaces_listener_on_week_change():
     listener2 = MagicMock()
     query.on_snapshot.side_effect = [listener1, listener2]
     with patch("todo._get_db", return_value=db), patch(
-        "streamlit.experimental_rerun", create=True
+        "streamlit.rerun", create=True
     ):
         todo.load_tasks("w1")
         todo.load_tasks("w2")
@@ -97,7 +97,7 @@ def test_load_templates_snapshot_updates_state_and_reruns():
 
     query.on_snapshot.side_effect = on_snapshot
     with patch("social_templates._get_db", return_value=db), patch(
-        "streamlit.experimental_rerun", create=True
+        "streamlit.rerun", create=True
     ) as rerun:
         assert social_templates.load_templates() == []
         callback_holder["cb"](

--- a/todo.py
+++ b/todo.py
@@ -53,7 +53,7 @@ def load_tasks(week: str):
                 data["id"] = doc.id
                 tasks.append(data)
             state["tasks"] = tasks
-            st.experimental_rerun()
+            st.rerun()
 
         state["task_listener"] = query.on_snapshot(on_snapshot)
         state["task_listener_week"] = week


### PR DESCRIPTION
## Summary
- Replace deprecated `st.experimental_rerun()` with `st.rerun()` in app modules
- Update Firestore listener tests to patch `streamlit.rerun`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2d6bc0648832198fa0932fdd71984