### PR TITLE
Normalize assignment names and count retakes in leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 *.pdf
 *.csv
+!tests/data/leaderboard_sample.csv
 .env
 *.env

--- a/tests/data/leaderboard_sample.csv
+++ b/tests/data/leaderboard_sample.csv
@@ -1,0 +1,5 @@
+studentcode,name,level,assignment,score
+S1,Alice,A1,Quiz 1,5
+S1,Alice,A1,Quiz 1 ,10
+S1,Alice,A1,QUIZ 1,8
+S2,Bob,A1,Quiz 1,7

--- a/tests/test_leaderboard_counts.py
+++ b/tests/test_leaderboard_counts.py
@@ -1,0 +1,35 @@
+import ast
+import pathlib
+
+import pandas as pd
+
+
+def load_rank_students():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_nodes = [
+        node
+        for node in ast.walk(module_ast)
+        if isinstance(node, ast.FunctionDef) and node.name == "rank_students"
+    ]
+    mod = ast.Module(body=func_nodes, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, filename="email.py", mode="exec")
+    ns = {"pd": pd}
+    exec(code, ns)
+    return ns["rank_students"]
+
+
+def test_rank_students_counts():
+    rank_students = load_rank_students()
+    csv_path = pathlib.Path(__file__).parent / "data" / "leaderboard_sample.csv"
+    df = pd.read_csv(csv_path)
+    ranked = rank_students(df, min_assign=1)
+
+    alice = ranked[ranked["studentcode"] == "S1"].iloc[0]
+    bob = ranked[ranked["studentcode"] == "S2"].iloc[0]
+
+    assert alice["completed"] == 3
+    assert alice["total_score"] == 23
+    assert bob["completed"] == 1
+    assert bob["total_score"] == 7


### PR DESCRIPTION
## Summary
- Add `rank_students` helper that strips and lowercases assignment names, summing scores and counting every attempt.
- Use `rank_students` in the leaderboard to include retakes and avoid case/whitespace discrepancies.
- Add test dataset and unit test covering duplicate/retake scenarios.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f24eee348321b863360557af123e