### PR TITLE
Ensure assignment leaderboard fetches all rows

### DIFF
--- a/email.py
+++ b/email.py
@@ -1605,7 +1605,7 @@ elif selected_tab == tab_titles[6]:
     # --- Config: the sheet you gave me (converted to CSV export) ---
     ASSIGNMENTS_CSV_URL = (
         "https://docs.google.com/spreadsheets/d/"
-        "1BRb8p3Rq0VpFCLSwL4eS9tSgXBo9hSWzfW_J_7W36NQ/export?format=csv&gid=2121051612"
+        "1BRb8p3Rq0VpFCLSwL4eS9tSgXBo9hSWzfW_J_7W36NQ/gviz/tq?tqx=out:csv&tq=select%20*&gid=2121051612"
     )
 
     # --- Helpers (reuse your style) ---

--- a/tests/test_read_csv_with_retry_no_truncation.py
+++ b/tests/test_read_csv_with_retry_no_truncation.py
@@ -1,0 +1,39 @@
+import ast
+import pathlib
+from io import BytesIO
+import pandas as pd
+
+
+def load_functions():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_nodes = [
+        node
+        for node in ast.walk(module_ast)
+        if isinstance(node, ast.FunctionDef) and node.name in {"read_csv_with_retry", "rank_students"}
+    ]
+    mod = ast.Module(body=func_nodes, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    ns = {"pd": pd, "BytesIO": BytesIO}
+    exec(compile(mod, filename="email.py", mode="exec"), ns)
+    return ns
+
+
+def test_read_csv_with_retry_no_truncation():
+    ns = load_functions()
+    read_csv_with_retry = ns["read_csv_with_retry"]
+    rank_students = ns["rank_students"]
+
+    csv_lines = ["studentcode,name,assignment,score"]
+    for i in range(10):
+        csv_lines.append(f"S1,Alice,HW{i},1")
+    csv_data = "\n".join(csv_lines).encode("utf-8")
+
+    ns["fetch_url"] = lambda url: csv_data
+
+    df = read_csv_with_retry("http://example.com")
+    assert len(df) == 10
+
+    ranked = rank_students(df, min_assign=1)
+    alice = ranked[ranked["studentcode"] == "S1"].iloc[0]
+    assert alice["completed"] == 10


### PR DESCRIPTION
## Summary
- Request full assignment sheet via explicit gviz CSV query to avoid truncated results.
- Add regression test confirming `read_csv_with_retry` and `rank_students` handle datasets with more than eight assignments per student.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f734d7a4832197f07daf101e418c