### PR TITLE
Add student ranking utility

### DIFF
--- a/student_stats.py
+++ b/student_stats.py
@@ -1,0 +1,86 @@
+import pandas as pd
+from typing import Optional
+
+try:
+    import firebase_admin
+    from firebase_admin import firestore
+except ModuleNotFoundError:  # fallback if firebase is not installed
+    firebase_admin = None
+    firestore = None
+
+
+def _load_assignments_from_firestore(collection: str) -> pd.DataFrame:
+    """Load assignment results from a Firestore collection.
+
+    The Firestore documents are expected to contain ``studentcode``, ``assignment``
+    and ``score`` fields. An optional ``level`` field may be present; if not,
+    it will be obtained from ``students.csv`` during merging.
+    """
+    if firebase_admin is None:
+        raise ImportError("firebase_admin is required for Firestore operations")
+
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app()
+    db = firestore.client()
+    docs = db.collection(collection).stream()
+    data = [doc.to_dict() for doc in docs]
+    return pd.DataFrame(data)
+
+
+def load_and_rank_students(
+    students_csv: str,
+    assignments_csv: Optional[str] = None,
+    firestore_collection: Optional[str] = None,
+) -> pd.DataFrame:
+    """Load student and assignment data and produce ranked results.
+
+    Exactly one of ``assignments_csv`` or ``firestore_collection`` must be
+    provided.
+
+    Parameters
+    ----------
+    students_csv:
+        Path to the ``students.csv`` file.
+    assignments_csv:
+        Optional path to a CSV with columns ``studentcode``, ``assignment``,
+        ``score`` and optionally ``level``.
+    firestore_collection:
+        Name of a Firestore collection containing assignment documents.
+
+    Returns
+    -------
+    ``pandas.DataFrame`` with columns ``StudentCode``, ``Level``,
+    ``assignment_count``, ``total_score`` and ``rank``.
+    """
+
+    if bool(assignments_csv) == bool(firestore_collection):
+        raise ValueError("Specify exactly one of assignments_csv or firestore_collection")
+
+    students_df = pd.read_csv(students_csv)
+    student_levels = students_df[["StudentCode", "Level", "Name"]]
+
+    if assignments_csv:
+        assignments_df = pd.read_csv(assignments_csv)
+    else:
+        assignments_df = _load_assignments_from_firestore(firestore_collection)
+
+    merged = assignments_df.merge(
+        student_levels,
+        left_on=["studentcode", "level"],
+        right_on=["StudentCode", "Level"],
+        how="inner",
+    )
+
+    summary = (
+        merged.groupby(["StudentCode", "Name", "Level"])
+        .agg(assignments_count=("assignment", "count"), total_score=("score", "sum"))
+        .reset_index()
+    )
+
+    summary = summary[summary["assignments_count"] >= 3]
+
+    summary["rank"] = summary.groupby("Level")["total_score"].rank(
+        ascending=False, method="dense"
+    )
+
+    return summary.sort_values(["Level", "rank", "StudentCode"]).reset_index(drop=True)

--- a/tests/test_student_stats.py
+++ b/tests/test_student_stats.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import tempfile
+from pathlib import Path
+
+from student_stats import load_and_rank_students
+
+
+def _write_csv(path: Path, data: str) -> None:
+    path.write_text(data)
+
+
+def test_load_and_rank_students(tmp_path: Path) -> None:
+    students_data = (
+        "Name,Level,StudentCode\n"
+        "Alice,A1,a1\n"
+        "Bob,A1,b1\n"
+        "Cara,A2,c1\n"
+    )
+    assignments_data = (
+        "studentcode,assignment,score,level\n"
+        "a1,hw1,80,A1\n"
+        "a1,hw2,90,A1\n"
+        "a1,hw3,70,A1\n"
+        "b1,hw1,50,A1\n"
+        "b1,hw2,60,A1\n"
+        "c1,hw1,85,A2\n"
+        "c1,hw2,95,A2\n"
+        "c1,hw3,90,A2\n"
+        "c1,hw4,100,A2\n"
+    )
+
+    students_csv = tmp_path / "students.csv"
+    assignments_csv = tmp_path / "assignments.csv"
+    _write_csv(students_csv, students_data)
+    _write_csv(assignments_csv, assignments_data)
+
+    result = load_and_rank_students(
+        students_csv=students_csv,
+        assignments_csv=assignments_csv,
+    )
+
+    expected = pd.DataFrame(
+        {
+            "StudentCode": ["a1", "c1"],
+            "Name": ["Alice", "Cara"],
+            "Level": ["A1", "A2"],
+            "assignments_count": [3, 4],
+            "total_score": [240, 370],
+            "rank": [1.0, 1.0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)


### PR DESCRIPTION
## Summary
- add `load_and_rank_students` for ranking students by assignment scores with CSV or Firestore input
- support Firestore loading and student assignment summarization
- test student ranking logic on sample data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c523362fcc83219f10e0fae822b96d