### PR TITLE
Add leaderboard page

### DIFF
--- a/pages/leaderboard.py
+++ b/pages/leaderboard.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import streamlit as st
+
+from student_stats import load_and_rank_students
+
+st.title("\U0001F3C6 Leaderboard")
+
+
+@st.cache_data(show_spinner="Loading leaderboard...")
+def load_leaderboard() -> pd.DataFrame:
+    """Load ranked student results."""
+    students_csv = st.secrets.get("students_csv", "students.csv")
+    assignments_csv = st.secrets.get("assignments_csv")
+    firestore_collection = st.secrets.get("assignments_collection")
+    try:
+        return load_and_rank_students(
+            students_csv=students_csv,
+            assignments_csv=assignments_csv,
+            firestore_collection=firestore_collection,
+        )
+    except Exception as exc:  # pragma: no cover - network / config errors
+        st.error(f"Failed to load leaderboard: {exc}")
+        return pd.DataFrame()
+
+
+if st.button("Refresh leaderboard"):
+    load_leaderboard.clear()
+    st.experimental_rerun()
+
+leaderboard_df = load_leaderboard()
+
+if leaderboard_df.empty:
+    st.info("No leaderboard data available.")
+else:
+    for level, group in leaderboard_df.groupby("Level"):
+        st.subheader(f"Level {level}")
+        display_df = group[
+            ["rank", "Name", "StudentCode", "assignments_count", "total_score"]
+        ].rename(
+            columns={
+                "rank": "Rank",
+                "Name": "Name",
+                "StudentCode": "Code",
+                "assignments_count": "Assignments",
+                "total_score": "Total Score",
+            }
+        )
+        st.table(display_df.reset_index(drop=True))


### PR DESCRIPTION
## Summary
- Add Streamlit leaderboard page to display ranked students per level
- Load leaderboard data from `load_and_rank_students` with cache and refresh button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c523e1ad748321baabf8088dc736bc