### PR TITLE
Filter leaderboard to students with 3+ assignments and group by level

### DIFF
--- a/pages/leaderboard.py
+++ b/pages/leaderboard.py
@@ -20,6 +20,7 @@ def load_leaderboard() -> pd.DataFrame:
             students_csv=students_csv,
             assignments_csv=assignments_csv,
             firestore_collection=firestore_collection,
+            min_assignments=3,
         )
     except Exception as exc:  # pragma: no cover - network / config errors
         st.error(f"Failed to load leaderboard: {exc}")

--- a/student_stats.py
+++ b/student_stats.py
@@ -31,11 +31,16 @@ def load_and_rank_students(
     students_csv: str,
     assignments_csv: Optional[str] = None,
     firestore_collection: Optional[str] = None,
+    *,
+    min_assignments: int = 3,
 ) -> pd.DataFrame:
     """Load student and assignment data and produce ranked results.
 
     Exactly one of ``assignments_csv`` or ``firestore_collection`` must be
     provided.
+
+    Students with fewer than ``min_assignments`` completed assignments are
+    excluded from the results.
 
     Parameters
     ----------
@@ -46,11 +51,14 @@ def load_and_rank_students(
         ``score`` and optionally ``level``.
     firestore_collection:
         Name of a Firestore collection containing assignment documents.
+    min_assignments:
+        Minimum number of assignments a student must have completed to appear
+        on the leaderboard.
 
     Returns
     -------
     ``pandas.DataFrame`` with columns ``StudentCode``, ``Level``,
-    ``assignment_count``, ``total_score`` and ``rank``.
+    ``assignments_count``, ``total_score`` and ``rank``.
     """
 
     if bool(assignments_csv) == bool(firestore_collection):
@@ -77,7 +85,7 @@ def load_and_rank_students(
         .reset_index()
     )
 
-    summary = summary[summary["assignments_count"] >= 3]
+    summary = summary[summary["assignments_count"] >= min_assignments]
 
     summary["rank"] = summary.groupby("Level")["total_score"].rank(
         ascending=False, method="dense"


### PR DESCRIPTION
## Summary
- Allow `load_and_rank_students` to exclude students with too few assignments
- Use parameter to show only students with 3+ assignments on leaderboard grouped by level

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c53db78c888321ab9dc270b8fbf45f