### PR TITLE
Add assignment links to leaderboard and tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+ASSIGNMENT_LINKS = {
+    "hw1": "https://example.com/hw1",
+    "hw2": "https://example.com/hw2",
+    "hw3": "https://example.com/hw3",
+    "hw4": "https://example.com/hw4",
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for direct imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_assignment_links.py
+++ b/tests/test_assignment_links.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pandas as pd
+
+from student_stats import load_and_rank_students
+from config import ASSIGNMENT_LINKS
+
+
+def _write_csv(path: Path, data: str) -> None:
+    path.write_text(data)
+
+
+def test_assignment_links_join(tmp_path: Path) -> None:
+    students_data = (
+        "Name,Level,StudentCode\n"
+        "Alice,A1,a1\n"
+    )
+    assignments_data = (
+        "studentcode,assignment,score,level\n"
+        "a1,hw1,80,A1\n"
+        "a1,unknown,70,A1\n"
+    )
+    students_csv = tmp_path / "students.csv"
+    assignments_csv = tmp_path / "assignments.csv"
+    _write_csv(students_csv, students_data)
+    _write_csv(assignments_csv, assignments_data)
+
+    summary, assignments = load_and_rank_students(
+        students_csv=students_csv,
+        assignments_csv=assignments_csv,
+        return_assignments=True,
+    )
+
+    assert "assignment_link" in assignments.columns
+
+    hw1_link = assignments.loc[assignments["assignment"] == "hw1", "assignment_link"].iloc[0]
+    assert hw1_link == ASSIGNMENT_LINKS["hw1"]
+
+    unknown_link = assignments.loc[
+        assignments["assignment"] == "unknown", "assignment_link"
+    ].iloc[0]
+    assert pd.isna(unknown_link)
+


### PR DESCRIPTION
## Summary
- map assignment names to URLs in a new `ASSIGNMENT_LINKS` config
- join assignments with their URLs when ranking students
- show clickable assignment links on the leaderboard page and cover with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c53ce6ad648321ad64c2962de3073a