### PR TITLE
Replace experimental rerun with st.rerun

### DIFF
--- a/pages/leaderboard.py
+++ b/pages/leaderboard.py
@@ -29,7 +29,7 @@ def load_leaderboard() -> pd.DataFrame:
 
 if st.button("Refresh leaderboard"):
     load_leaderboard.clear()
-    st.experimental_rerun()
+    st.rerun()
 
 leaderboard_df = load_leaderboard()
 


### PR DESCRIPTION
## Summary
- Update leaderboard refresh logic to use Streamlit's current `st.rerun()` API.

## Testing
- `pytest`
- `streamlit run pages/leaderboard.py` *(confirmed server startup via HTTP 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c5407b26948321a1be897cef7762ea