### PR TITLE
chore: remove tasks feature references

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,12 +1,4 @@
 {
-  "indexes": [
-    {
-      "collectionGroup": "tasks",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {"fieldPath": "week", "order": "ASCENDING"}
-      ]
-    }
-  ],
+  "indexes": [],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,10 +1,6 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /tasks/{taskId} {
-      allow read: if request.query.selectFields.hasOnly(['description','assignee','week','due','completed']);
-      allow write: if true;
-    }
     match /templates/{templateId} {
       allow read: if request.query.selectFields.hasOnly(['title','platform','content']);
       allow write: if true;


### PR DESCRIPTION
## Summary
- remove obsolete `/tasks` match block from Firestore rules
- drop Firestore index for `tasks` collection
- confirm no references to to-do list functionality remain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6888bdc10832193722234abd2b40c