### PR TITLE
Prefer highest score when deduping leaderboard attempts

### DIFF
--- a/leaderboard_logic.py
+++ b/leaderboard_logic.py
@@ -24,16 +24,16 @@ def _canon_assignment(s: str | None) -> str:
 
 def _dedupe_latest_attempt(scores_df: pd.DataFrame) -> pd.DataFrame:
     """
-    Keep only the latest attempt per (StudentCode, AssignmentKey).
-    If same date appears twice, keep the higher score.
+    Keep only the best attempt per (StudentCode, AssignmentKey).
+    Prefer higher scores; break score ties by the most recent date.
     """
     tmp = scores_df.copy()
     tmp["_AssignmentKey"] = tmp["Assignment"].apply(_canon_assignment)
 
-    # Order so that the last row per group is kept:
-    #   1) by Date ascending (latest is last)
-    #   2) by Score ascending (higher last if same date)
-    tmp = tmp.sort_values(["Date", "Score"], ascending=[True, True])
+    # Order so that the last row per group is the preferred attempt:
+    #   1) by Score ascending (highest score is last)
+    #   2) by Date ascending (latest is last when scores tie)
+    tmp = tmp.sort_values(["Score", "Date"], ascending=[True, True])
 
     keep_idx = tmp.groupby(["StudentCode", "_AssignmentKey"], dropna=False).tail(1).index
     kept = tmp.loc[keep_idx].drop(columns=["_AssignmentKey"])

--- a/pages/02_Leaderboards.py
+++ b/pages/02_Leaderboards.py
@@ -166,16 +166,16 @@ def _canon_assignment(s: str | None) -> str:
 
 def _dedupe_latest_attempt(scores_df: pd.DataFrame) -> pd.DataFrame:
     """
-    Keep only the latest attempt per (StudentCode, AssignmentKey).
-    If same date appears twice, keep the higher score.
+    Keep only the best attempt per (StudentCode, AssignmentKey).
+    Prefer higher scores; break score ties by the most recent date.
     """
     tmp = scores_df.copy()
     tmp["_AssignmentKey"] = tmp["Assignment"].apply(_canon_assignment)
 
-    # Order so that the last row per group is kept:
-    #   1) by Date ascending (latest is last)
-    #   2) by Score ascending (higher last if same date)
-    tmp = tmp.sort_values(["Date", "Score"], ascending=[True, True])
+    # Order so that the last row per group is the preferred attempt:
+    #   1) by Score ascending (highest score is last)
+    #   2) by Date ascending (latest is last when scores tie)
+    tmp = tmp.sort_values(["Score", "Date"], ascending=[True, True])
 
     keep_idx = tmp.groupby(["StudentCode", "_AssignmentKey"], dropna=False).tail(1).index
     kept = tmp.loc[keep_idx].drop(columns=["_AssignmentKey"])

--- a/tests/test_leaderboard_logic.py
+++ b/tests/test_leaderboard_logic.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pandas as pd
+
+
+spec = importlib.util.spec_from_file_location(
+    "leaderboard_logic", pathlib.Path(__file__).resolve().parents[1] / "leaderboard_logic.py"
+)
+leaderboard_logic = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(leaderboard_logic)
+
+
+def test_dedupe_prefers_highest_score_then_latest_date():
+    df = pd.DataFrame(
+        {
+            "StudentCode": ["s1", "s1", "s1"],
+            "Name": ["Alice", "Alice", "Alice"],
+            "Assignment": ["Essay 1", "Essay 1", "Essay 1"],
+            "Score": [70, 95, 95],
+            "Date": [
+                pd.Timestamp("2024-01-03"),
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-02"),
+            ],
+            "Level": ["A1", "A1", "A1"],
+        }
+    )
+
+    deduped = leaderboard_logic._dedupe_latest_attempt(df)
+
+    assert len(deduped) == 1
+    kept = deduped.iloc[0]
+    assert kept["Score"] == 95
+    assert kept["Date"] == pd.Timestamp("2024-01-02")


### PR DESCRIPTION
## Summary
- update leaderboard attempt dedupe helper to prefer the highest score and break ties by the most recent date in both the core logic and Streamlit page
- add a regression test covering multiple attempts where the top score is not the latest submission

## Testing
- pytest tests/test_leaderboard_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5d4174d4832193e070d513f8c7f7