### PR TITLE
Handle missing days_left when generating reminders

### DIFF
--- a/tests/test_compute_days_and_message.py
+++ b/tests/test_compute_days_and_message.py
@@ -1,0 +1,31 @@
+import ast
+import pathlib
+
+import pandas as pd
+
+
+def load_namespace():
+    source = (pathlib.Path(__file__).resolve().parents[1] / "email.py").read_text()
+    module_ast = ast.parse(source)
+    func_nodes = [
+        node
+        for node in ast.walk(module_ast)
+        if isinstance(node, ast.FunctionDef) and node.name == "compute_days_and_message"
+    ]
+    mod = ast.Module(body=func_nodes, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, filename="email.py", mode="exec")
+    ns = {"pd": pd}
+    exec(code, ns)
+    return ns
+
+
+def test_compute_days_and_message_handles_missing_days_left():
+    ns = load_namespace()
+    compute_days_and_message = ns["compute_days_and_message"]
+
+    row = pd.Series({"days_left": float("nan")})
+    days, msg = compute_days_and_message(row["days_left"], "GHS 0.00")
+
+    assert days == "N/A"
+    assert "balance" in msg.lower()


### PR DESCRIPTION
## Summary
- add a helper to compute reminder day counts and fallback messaging when days_left is missing
- update the WhatsApp/email reminder generation to rely on the helper so templates receive safe values
- cover the helper with a unit test to ensure missing days_left no longer causes an exception

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a84c6a4c8321aaaba99b1548b1d3