### PR TITLE
Add Blog page, Sedifex retries, and normalize product/course catalog parsing

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { SectionHeading } from '@/components/section-heading';
+import { getBlogPosts } from '@/data/blog';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Read published beauty education articles, class insights, and product guidance from Make Up & More School of Cosmetology.'
+};
+
+function formatPublishedAt(value?: string) {
+  if (!value) return 'Recently published';
+  return new Date(value).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+export default async function BlogPage() {
+  const posts = await getBlogPosts();
+
+  return (
+    <div className="section-shell py-16 sm:py-20">
+      <SectionHeading
+        eyebrow="Blog"
+        title="Beauty insights, student tips, and industry updates."
+        description="This page pulls published posts directly from Sedifex public blog feed with graceful local fallback content."
+      />
+      <div className="mt-10 grid gap-6 lg:grid-cols-2">
+        {posts.map((post) => (
+          <article key={post.id} className="overflow-hidden rounded-4xl border border-black/5 bg-white shadow-card">
+            {post.imageUrl ? (
+              <div className="relative aspect-[16/9]">
+                <Image src={post.imageUrl} alt={post.title} fill className="object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
+              </div>
+            ) : null}
+            <div className="space-y-4 p-7">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gold">{formatPublishedAt(post.publishedAt)}</p>
+              <h2 className="text-2xl font-semibold text-charcoal">{post.title}</h2>
+              <p className="text-sm leading-7 text-charcoal/70">{post.excerpt || 'Read the full post for details.'}</p>
+              <div className="flex gap-3">
+                {post.linkUrl ? (
+                  <Link href={post.linkUrl} target="_blank" rel="noreferrer" className="rounded-full bg-charcoal px-5 py-3 text-sm font-medium text-white transition hover:bg-charcoal/90">
+                    Continue reading
+                  </Link>
+                ) : null}
+                <span className="rounded-full bg-nude px-4 py-3 text-sm text-charcoal/75">/{post.slug}</span>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/upcoming-classes-section.tsx
+++ b/src/components/upcoming-classes-section.tsx
@@ -67,7 +67,6 @@ export function UpcomingClassesSection({ preview = false, classes }: { preview?:
               </dl>
               <div className="mt-7 flex flex-wrap gap-3">
                 <ButtonLink href={reserveClassWhatsAppLink(item.name)} external>Reserve on WhatsApp</ButtonLink>
-                <ButtonLink href="/register" variant="secondary">Register online</ButtonLink>
               </div>
             </div>
           </article>

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -1,0 +1,56 @@
+import { getSedifexPublicBlog, type SedifexBlogPost } from '@/lib/server/sedifex';
+
+export type BlogPost = {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string;
+  imageUrl?: string;
+  linkUrl?: string;
+  publishedAt?: string;
+};
+
+const fallbackPosts: BlogPost[] = [
+  {
+    id: 'fallback-1',
+    title: 'How to prepare for your first beauty class',
+    slug: 'how-to-prepare-for-your-first-beauty-class',
+    content: '<p>Bring your notepad, arrive early, and come ready for practical learning.</p>',
+    excerpt: 'Bring your notepad, arrive early, and come ready for practical learning.',
+    publishedAt: '2026-04-01T10:00:00.000Z'
+  }
+];
+
+function stripHtml(input = '') {
+  return input.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function toExcerpt(content?: string) {
+  const plain = stripHtml(content);
+  return plain.length > 160 ? `${plain.slice(0, 157)}...` : plain;
+}
+
+function mapPost(post: SedifexBlogPost): BlogPost {
+  return {
+    id: post.id,
+    title: post.title,
+    slug: post.slug,
+    content: post.content || '',
+    excerpt: toExcerpt(post.content),
+    imageUrl: post.imageUrl,
+    linkUrl: post.linkUrl,
+    publishedAt: post.publishedAt
+  };
+}
+
+export async function getBlogPosts(): Promise<BlogPost[]> {
+  try {
+    const payload = await getSedifexPublicBlog();
+    const items = Array.isArray(payload?.items) ? payload.items : [];
+    if (items.length) return items.map(mapPost);
+  } catch (error) {
+    console.warn('Falling back to local blog posts:', error);
+  }
+  return fallbackPosts;
+}

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -23,9 +23,11 @@ function toSlug(name: string) {
 export async function getCourses() {
   try {
     const catalog = await getSedifexIntegrationProducts();
-    const services = (catalog?.publicServices || []) as SedifexCatalogItem[];
-    if (services.length) {
-      return services.map((service) => ({
+    const catalogItems = (catalog?.products || []) as SedifexCatalogItem[];
+    const services = catalogItems.filter((item) => item.itemType?.toLowerCase() === 'service');
+    const normalizedServices = services.length ? services : ((catalog?.publicServices || []) as SedifexCatalogItem[]);
+    if (normalizedServices.length) {
+      return normalizedServices.map((service) => ({
         slug: toSlug(service.name),
         name: service.name,
         duration: 'See schedule',

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -20,9 +20,11 @@ function formatPrice(value?: number) {
 export async function getProducts() {
   try {
     const catalog = await getSedifexIntegrationProducts();
-    const publicProducts = (catalog?.publicProducts || []) as SedifexCatalogItem[];
-    if (publicProducts.length) {
-      return publicProducts.map((item) => ({
+    const catalogItems = (catalog?.products || []) as SedifexCatalogItem[];
+    const productItems = catalogItems.filter((item) => item.itemType?.toLowerCase() === 'product');
+    const normalizedProducts = productItems.length ? productItems : ((catalog?.publicProducts || []) as SedifexCatalogItem[]);
+    if (normalizedProducts.length) {
+      return normalizedProducts.map((item) => ({
         name: item.name,
         image: item.imageUrl || '/uploads/products/radiance-facial-kit.svg',
         description: item.description || 'Professional beauty product',

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -29,6 +29,7 @@ export const navigation = [
   { href: '/upcoming-classes', label: 'Upcoming Classes' },
   { href: '/gallery', label: 'Gallery' },
   { href: '/products', label: 'Products' },
+  { href: '/blog', label: 'Blog' },
   { href: '/register', label: 'Register' },
   { href: '/contact', label: 'Contact' }
 ];

--- a/src/lib/server/sedifex.ts
+++ b/src/lib/server/sedifex.ts
@@ -32,9 +32,28 @@ async function sedifexFetch(path: string, authenticated = false) {
     headers['x-api-key'] = apiKey;
   }
 
-  const response = await fetch(`${baseUrl}${path}`, { headers, next: { revalidate: 60 } });
-  if (!response.ok) throw new Error(`Sedifex request failed (${response.status}) for ${path}`);
-  return response.json();
+  const url = `${baseUrl}${path}`;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await fetch(url, { headers, next: { revalidate: 60 } });
+
+    if (response.ok) {
+      return response.json();
+    }
+
+    const requestId = response.headers.get('x-sedifex-request-id') || 'n/a';
+    const retryable = response.status >= 500 || response.status === 429;
+
+    if (!retryable || attempt === 2) {
+      throw new Error(`Sedifex request failed (${response.status}) for ${path}. requestId=${requestId}`);
+    }
+
+    const delayMs = 250 * 2 ** attempt;
+    console.warn(`Retrying Sedifex GET ${path} after ${response.status}. requestId=${requestId}. attempt=${attempt + 1}`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error(`Sedifex request failed for ${path}`);
 }
 
 export type SedifexCatalogItem = {
@@ -46,6 +65,16 @@ export type SedifexCatalogItem = {
   price?: number;
   itemType?: string;
   updatedAt?: string;
+};
+
+export type SedifexBlogPost = {
+  id: string;
+  title: string;
+  slug: string;
+  content?: string;
+  linkUrl?: string;
+  imageUrl?: string;
+  publishedAt?: string;
 };
 
 export async function getSedifexIntegrationProducts() {
@@ -64,4 +93,12 @@ export async function getSedifexAvailability() {
   const storeId = getStoreId();
   if (!storeId || !getApiKey()) return null;
   return sedifexFetch(`/v1IntegrationAvailability?storeId=${encodeURIComponent(storeId)}`, true);
+}
+
+export async function getSedifexPublicBlog(slug?: string) {
+  const storeId = getStoreId();
+  if (!storeId) return null;
+  const params = new URLSearchParams({ storeId });
+  if (slug) params.set('slug', slug);
+  return sedifexFetch(`/api/public-blog?${params.toString()}`);
 }


### PR DESCRIPTION
### Motivation
- Provide a public-facing blog page that pulls published posts from the Sedifex public blog feed with a graceful local fallback. 
- Improve reliability of Sedifex API calls by adding retry/backoff logic for transient errors. 
- Support a changed Sedifex catalog shape by normalizing parsing of products and services so the site can consume `products` responses and fall back to legacy `publicProducts`/`publicServices` fields. 

### Description
- Add a new blog UI at `src/app/blog/page.tsx` that renders posts from `getBlogPosts()` with image, excerpt, and external links. 
- Add `src/data/blog.ts` implementing `getBlogPosts()` with a local `fallbackPosts`, HTML stripping/excerpting, and mapping from `SedifexBlogPost`. 
- Extend the Sedifex server client in `src/lib/server/sedifex.ts` with retry/backoff on GET failures, include response `x-sedifex-request-id` in errors/logs, and add `getSedifexPublicBlog()` plus `SedifexBlogPost` type. 
- Normalize catalog handling in `src/data/courses.ts` and `src/data/products.ts` to prefer `catalog.products` and filter by `itemType` (`service`/`product`), and fall back to `publicServices`/`publicProducts` when needed, preserving existing local fallbacks. 
- Add a `/blog` navigation item in `src/data/site.ts`. 
- Remove the direct "Register online" button from the upcoming classes UI in `src/components/upcoming-classes-section.tsx` to streamline CTA options. 

### Testing
- Ran TypeScript type checking with `tsc --noEmit` and it completed successfully. 
- Built the app with `next build` and the build succeeded without errors. 
- Ran `eslint` across changed files and there were no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a4253c048321bfbe2ec824c197d8)