### PR TITLE
Support Vercel Sedifex env aliases (INTEGRATION_KEY, SEDIFEX/SEDFIEX variants)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Notes:
 - The server also accepts common aliases (`GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, `FIREBASE_ADMIN_CLIENT_EMAIL`, `FIREBASE_ADMIN_PRIVATE_KEY`, `GOOGLE_CLIENT_EMAIL`, `GOOGLE_PRIVATE_KEY`) to simplify Vercel setups.
 - Use a Firebase service account with access to Firestore.
 
+## Sedifex integration environment variables
+
+For live Sedifex-powered products/classes/blog, set these server-side env vars in Vercel:
+
+```bash
+SEDIFEX_STORE_ID=your-store-id
+SEDIFEX_INTEGRATION_API_KEY=your-integration-key
+```
+
+Accepted aliases (for compatibility): `SEDIFEX_INTEGRATION_KEY`, `SEDFIEX_INTEGRATION_KEY`, `SEDFIEX_API_KEY`, `INTEGRATION_KEY`, `SEDFIEX_STORE_ID`, and `INTEGRATION_STORE_ID`.
+
 ## Build for production
 
 ```bash

--- a/src/lib/server/sedifex.ts
+++ b/src/lib/server/sedifex.ts
@@ -10,11 +10,17 @@ function getBaseUrl() {
 }
 
 function getStoreId() {
-  return getEnv('SEDIFEX_STORE_ID');
+  return getEnv('SEDIFEX_STORE_ID', getEnv('SEDFIEX_STORE_ID', getEnv('INTEGRATION_STORE_ID')));
 }
 
 function getApiKey() {
-  return getEnv('SEDIFEX_INTEGRATION_API_KEY', getEnv('SEDIFEX_INTEGRATION_KEY'));
+  return getEnv(
+    'SEDIFEX_INTEGRATION_API_KEY',
+    getEnv(
+      'SEDIFEX_INTEGRATION_KEY',
+      getEnv('SEDFIEX_INTEGRATION_KEY', getEnv('SEDFIEX_API_KEY', getEnv('INTEGRATION_KEY')))
+    )
+  );
 }
 
 async function sedifexFetch(path: string, authenticated = false) {


### PR DESCRIPTION
### Motivation
- The site was silently falling back to local content when deployed with Vercel environment names that use integration-style keys or common misspellings, so Sedifex calls could not authenticate. 

### Description
- Extend Sedifex env lookup in `src/lib/server/sedifex.ts` so `getApiKey()` accepts multiple aliases including `SEDIFEX_INTEGRATION_API_KEY`, `SEDIFEX_INTEGRATION_KEY`, `SEDFIEX_INTEGRATION_KEY`, `SEDFIEX_API_KEY`, and `INTEGRATION_KEY`. 
- Extend `getStoreId()` to accept `SEDFIEX_STORE_ID` and `INTEGRATION_STORE_ID` as compatibility aliases. 
- Add README documentation for the required Sedifex env vars and the accepted aliases to make Vercel setup explicit (`README.md`).

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with TypeScript checks passing. 
- The build output shows pages were prerendered and dynamic API routes are present, indicating the change did not break the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e8bd3d648321b4c27937ab68ab5d)