### PR TITLE
Fix Sedifex integration data pull configuration

### DIFF
--- a/src/lib/server/sedifex.ts
+++ b/src/lib/server/sedifex.ts
@@ -1,12 +1,17 @@
 const CONTRACT_VERSION = '2026-04-13';
-const DEFAULT_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net';
+const DEFAULT_API_BASE_URL = 'https://us-central1-sedifex-web.cloudfunctions.net';
+const DEFAULT_SITE_BASE_URL = 'https://www.sedifex.com';
 
 function getEnv(name: string, fallback?: string) {
   return process.env[name] || fallback || '';
 }
 
-function getBaseUrl() {
-  return getEnv('SEDIFEX_API_BASE_URL', getEnv('SEDIFEX_INTEGRATION_API_BASE_URL', DEFAULT_BASE_URL)).replace(/\/$/, '');
+function getApiBaseUrl() {
+  return getEnv('SEDIFEX_API_BASE_URL', getEnv('SEDIFEX_INTEGRATION_API_BASE_URL', DEFAULT_API_BASE_URL)).replace(/\/$/, '');
+}
+
+function getSiteBaseUrl() {
+  return getEnv('SEDIFEX_SITE_BASE_URL', DEFAULT_SITE_BASE_URL).replace(/\/$/, '');
 }
 
 function getStoreId() {
@@ -23,8 +28,7 @@ function getApiKey() {
   );
 }
 
-async function sedifexFetch(path: string, authenticated = false) {
-  const baseUrl = getBaseUrl();
+async function sedifexFetch(path: string, authenticated = false, baseUrl = getApiBaseUrl()) {
   const headers: HeadersInit = {
     Accept: 'application/json',
     'X-Sedifex-Contract-Version': CONTRACT_VERSION
@@ -91,8 +95,8 @@ export async function getSedifexIntegrationProducts() {
 
 export async function getSedifexGallery() {
   const storeId = getStoreId();
-  if (!storeId) return null;
-  return sedifexFetch(`/integrationGallery?storeId=${encodeURIComponent(storeId)}`);
+  if (!storeId || !getApiKey()) return null;
+  return sedifexFetch(`/integrationGallery?storeId=${encodeURIComponent(storeId)}`, true);
 }
 
 export async function getSedifexAvailability() {
@@ -106,5 +110,5 @@ export async function getSedifexPublicBlog(slug?: string) {
   if (!storeId) return null;
   const params = new URLSearchParams({ storeId });
   if (slug) params.set('slug', slug);
-  return sedifexFetch(`/api/public-blog?${params.toString()}`);
+  return sedifexFetch(`/api/public-blog?${params.toString()}`, false, getSiteBaseUrl());
 }


### PR DESCRIPTION
### Motivation

- Ensure integration client follows the published Sedifex guide by clearly separating API vs site hosts so public blog pulls target the public site host. 
- Require authentication for endpoints that should be called with an integration key (gallery/availability) to avoid missing store-scoped data. 

### Description

- Add `DEFAULT_SITE_BASE_URL` and a `getSiteBaseUrl()` helper while renaming the API host helper to `getApiBaseUrl()` so hosts are kept separate. 
- Update `sedifexFetch()` to accept an optional `baseUrl` parameter and keep the existing contract header and retry/backoff behavior. 
- Switch `getSedifexGallery()` to require an API key and call `sedifexFetch()` in authenticated mode. 
- Change `getSedifexPublicBlog()` to call the public blog via the site base URL by passing `getSiteBaseUrl()` to `sedifexFetch()`. 

### Testing

- Ran `npm run build` and the Next.js production build completed successfully. 
- Ran `npm run lint` which failed due to a repository lint script/config issue (`next lint` receiving an invalid directory argument), not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061a1b6b78832184a1990cc19506e0)