### PR TITLE
Allow Sedifex-hosted images to render on content pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,14 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
-    formats: ['image/avif', 'image/webp']
+    formats: ['image/avif', 'image/webp'],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'www.sedifex.com' },
+      { protocol: 'https', hostname: 'sedifex.com' },
+      { protocol: 'https', hostname: 'us-central1-sedifex-web.cloudfunctions.net' },
+      { protocol: 'https', hostname: 'firebasestorage.googleapis.com' },
+      { protocol: 'https', hostname: '*.googleusercontent.com' }
+    ]
   }
 };
 


### PR DESCRIPTION
### Motivation
- Product, Course, Gallery, and Blog pages may receive externally hosted image URLs from Sedifex and related storage providers, and `next/image` must be configured to allow those remote hosts so images can render.

### Description
- Updated `next.config.ts` to add `images.remotePatterns` entries (for `www.sedifex.com`, `sedifex.com`, `us-central1-sedifex-web.cloudfunctions.net`, `firebasestorage.googleapis.com`, and `*.googleusercontent.com`) so Sedifex-hosted images are allowlisted for `next/image`.

### Testing
- Ran `npm run typecheck` which passed, and `npm run lint` which failed due to an existing environment/tooling issue (`next lint` reports an invalid project directory in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062823e53c8321adb37a26e080f933)