### PR TITLE
Add slug-based course/blog pages and fix Sedifex images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'sedifex.com' },
       { protocol: 'https', hostname: 'us-central1-sedifex-web.cloudfunctions.net' },
       { protocol: 'https', hostname: 'firebasestorage.googleapis.com' },
+      { protocol: 'https', hostname: 'storage.googleapis.com' },
       { protocol: 'https', hostname: '*.googleusercontent.com' }
     ]
   }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { getBlogPostBySlug, getBlogPosts } from '@/data/blog';
+
+export async function generateStaticParams() {
+  const posts = await getBlogPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getBlogPostBySlug(slug);
+  if (!post) return { title: 'Post not found' };
+  return { title: post.title, description: post.excerpt };
+}
+
+export default async function BlogPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = await getBlogPostBySlug(slug);
+  if (!post) notFound();
+
+  return (
+    <article className="section-shell py-16 sm:py-20">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <h1 className="text-4xl font-semibold text-charcoal">{post.title}</h1>
+        {post.imageUrl ? (
+          <div className="relative aspect-[16/9] overflow-hidden rounded-3xl">
+            <Image src={post.imageUrl} alt={post.title} fill className="object-cover" sizes="100vw" />
+          </div>
+        ) : null}
+        <div className="whitespace-pre-line text-base leading-8 text-charcoal/85">{post.content}</div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -37,11 +37,9 @@ export default async function BlogPage() {
               <h2 className="text-2xl font-semibold text-charcoal">{post.title}</h2>
               <p className="text-sm leading-7 text-charcoal/70">{post.excerpt || 'Read the full post for details.'}</p>
               <div className="flex gap-3">
-                {post.linkUrl ? (
-                  <Link href={post.linkUrl} target="_blank" rel="noreferrer" className="rounded-full bg-charcoal px-5 py-3 text-sm font-medium text-white transition hover:bg-charcoal/90">
-                    Continue reading
-                  </Link>
-                ) : null}
+                <Link href={`/blog/${post.slug}`} className="rounded-full bg-charcoal px-5 py-3 text-sm font-medium text-white transition hover:bg-charcoal/90">
+                  Continue reading
+                </Link>
                 <span className="rounded-full bg-nude px-4 py-3 text-sm text-charcoal/75">/{post.slug}</span>
               </div>
             </div>

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { getCourseBySlug, getCourses } from '@/data/courses';
+import { ButtonLink } from '@/components/button-link';
+import { registerWhatsAppLink } from '@/lib/whatsapp';
+
+export async function generateStaticParams() {
+  const courses = await getCourses();
+  return courses.map((course) => ({ slug: course.slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const course = await getCourseBySlug(slug);
+  if (!course) return { title: 'Course not found' };
+  return { title: course.name, description: course.summary };
+}
+
+export default async function CoursePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const course = await getCourseBySlug(slug);
+  if (!course) notFound();
+
+  return (
+    <article className="section-shell py-16 sm:py-20">
+      <div className="mx-auto max-w-4xl space-y-6">
+        <h1 className="text-4xl font-semibold text-charcoal">{course.name}</h1>
+        <div className="relative aspect-[16/9] overflow-hidden rounded-3xl">
+          <Image src={course.image} alt={course.imageAlt} fill className="object-cover" sizes="100vw" />
+        </div>
+        <p className="text-base leading-8 text-charcoal/85">{course.summary}</p>
+        <div className="flex gap-3">
+          <ButtonLink href="/register" variant="primary">Apply now</ButtonLink>
+          <ButtonLink href={registerWhatsAppLink(course.name)} variant="secondary" external>
+            Ask on WhatsApp
+          </ButtonLink>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/course-card.tsx
+++ b/src/components/course-card.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { Course } from '@/data/courses';
 import { registerWhatsAppLink } from '@/lib/whatsapp';
 import { ButtonLink } from './button-link';
+import { ExpandableText } from './expandable-text';
 
 export function CourseCard({ course }: { course: Course }) {
   return (
@@ -23,7 +24,7 @@ export function CourseCard({ course }: { course: Course }) {
           </div>
           <span className="rounded-full bg-nude px-4 py-2 text-sm text-charcoal/80">{course.duration}</span>
         </div>
-        <p className="mt-5 text-sm leading-7 text-charcoal/70">{course.summary}</p>
+        <ExpandableText text={course.summary} className="mt-5 text-sm leading-7 text-charcoal/70" />
         {course.modules?.length ? (
           <ul className="mt-6 space-y-3 text-sm text-charcoal/80">
             {course.modules.map((module) => (
@@ -35,7 +36,8 @@ export function CourseCard({ course }: { course: Course }) {
           </ul>
         ) : null}
         <div className="mt-7 flex flex-wrap gap-3">
-          <ButtonLink href="/register" variant="primary">Apply now</ButtonLink>
+          <ButtonLink href={`/courses/${course.slug}`} variant="primary">View details</ButtonLink>
+          <ButtonLink href="/register" variant="secondary">Apply now</ButtonLink>
           <ButtonLink href={registerWhatsAppLink(course.name)} variant="secondary" external>
             Ask on WhatsApp
           </ButtonLink>

--- a/src/components/expandable-text.tsx
+++ b/src/components/expandable-text.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type ExpandableTextProps = {
+  text: string;
+  maxLength?: number;
+  className?: string;
+};
+
+export function ExpandableText({ text, maxLength = 180, className }: ExpandableTextProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const isLong = text.length > maxLength;
+  const preview = useMemo(() => {
+    if (!isLong) return text;
+    return `${text.slice(0, maxLength).trimEnd()}...`;
+  }, [isLong, maxLength, text]);
+
+  return (
+    <div>
+      <p className={className}>{expanded || !isLong ? text : preview}</p>
+      {isLong ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="mt-2 text-sm font-medium text-gold underline-offset-4 hover:underline"
+        >
+          {expanded ? 'View less' : 'View more'}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -54,3 +54,8 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
   }
   return fallbackPosts;
 }
+
+export async function getBlogPostBySlug(slug: string): Promise<BlogPost | null> {
+  const posts = await getBlogPosts();
+  return posts.find((post) => post.slug === slug) || null;
+}

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -43,3 +43,8 @@ export async function getCourses() {
 
   return courses;
 }
+
+export async function getCourseBySlug(slug: string) {
+  const allCourses = await getCourses();
+  return allCourses.find((course) => course.slug === slug) || null;
+}


### PR DESCRIPTION
### Motivation
- Surface Sedifex-provided course and blog content on their own URLs and ensure Sedifex-hosted images render correctly. 
- Prevent long Sedifex descriptions from breaking card layouts by adding a compact preview with a toggle.

### Description
- Added a client `ExpandableText` component (`src/components/expandable-text.tsx`) and wired it into `CourseCard` so long course descriptions show a `View more / View less` toggle. 
- Updated `CourseCard` to show a `View details` link that navigates to the course-specific slug page (`/courses/[slug]`) while keeping register/WhatsApp actions. 
- Added course detail page at `src/app/courses/[slug]/page.tsx` with `generateStaticParams` and `generateMetadata`, and added `getCourseBySlug` to `src/data/courses.ts` to resolve courses by slug. 
- Added blog post detail page at `src/app/blog/[slug]/page.tsx`, switched list CTA links in `src/app/blog/page.tsx` to link to `/blog/{slug}`, and added `getBlogPostBySlug` to `src/data/blog.ts`. 
- Enabled `storage.googleapis.com` in `next.config.ts` `images.remotePatterns` so Sedifex/Google Storage image URLs load via Next Image. 

### Testing
- Ran the production build with `npm run build`, which completed successfully and TypeScript compiled without errors. 
- Build output shows generated SSG routes for `/courses/[slug]` and `/blog/[slug]` (pages were prerendered as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06444dd6b88321ae4b6fc0f16996e9)