### PR TITLE
Centralize canonical site URL and use it for metadata, sitemap, and robots

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { MobileWhatsAppCTA } from '@/components/mobile-whatsapp-cta';
 import { siteConfig } from '@/data/site';
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://makeup-and-more-school.vercel.app'),
+  metadataBase: new URL(siteConfig.url),
   title: {
     default: `${siteConfig.name} | Premium Beauty Training in Tema`,
     template: `%s | ${siteConfig.shortName}`

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/data/site';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/'
     },
-    sitemap: 'https://makeup-and-more-school.vercel.app/sitemap.xml'
+    sitemap: `${siteConfig.url}/sitemap.xml`
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,11 @@
 import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/data/site';
 
 const routes = ['', '/courses', '/upcoming-classes', '/gallery', '/products', '/register', '/contact'];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return routes.map((route) => ({
-    url: `https://makeup-and-more-school.vercel.app${route}`,
+    url: `${siteConfig.url}${route}`,
     lastModified: new Date(),
     changeFrequency: route === '' ? 'weekly' : 'monthly',
     priority: route === '' ? 1 : 0.8

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,4 +1,5 @@
 export const siteConfig = {
+  url: 'https://make-upmore.com',
   name: 'Make Up & More School of Cosmetology',
   shortName: 'Make Up & More',
   description:


### PR DESCRIPTION
### Motivation
- Provide a single canonical domain so all generated absolute URLs (metadata, sitemap, robots) use the correct production hostname.

### Description
- Added `url: 'https://make-upmore.com'` to `siteConfig` in `src/data/site.ts` to centralize the canonical domain.
- Switched the Next.js metadata base to `new URL(siteConfig.url)` in `src/app/layout.tsx` so OG and metadata use the canonical host.
- Updated `src/app/sitemap.ts` to build route URLs from `siteConfig.url` for all sitemap entries.
- Updated `src/app/robots.ts` to reference the sitemap at `${siteConfig.url}/sitemap.xml` and added the `siteConfig` import where needed.

### Testing
- Ran `npm run build` successfully and confirmed static routes (including `/sitemap.xml` and `/robots.txt`) are generated.
- Ran `npm run lint` which failed due to a project script/config issue (`next lint` reported an invalid directory argument), unrelated to the domain changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065bd90e908321bc1b0542d9a6fe3d)