### PR TITLE
Add SEO-friendly product & service detail pages, stable slugs, and sitemap entries

### DIFF
--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -14,7 +14,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const course = await getCourseBySlug(slug);
   if (!course) return { title: 'Course not found' };
-  return { title: course.name, description: course.summary };
+  return {
+    title: `${course.name} | Courses`,
+    description: course.summary,
+    alternates: { canonical: `/courses/${course.slug}` }
+  };
 }
 
 export default async function CoursePage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { ButtonLink } from '@/components/button-link';
+import { getProductBySlug, getProducts } from '@/data/products';
+import { productWhatsAppLink } from '@/lib/whatsapp';
+
+export async function generateStaticParams() {
+  const products = await getProducts();
+  return products.map((product) => ({ slug: product.slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const product = await getProductBySlug(slug);
+
+  if (!product) return { title: 'Product not found' };
+
+  return {
+    title: `${product.name} | Products`,
+    description: product.description,
+    alternates: { canonical: `/products/${product.slug}` }
+  };
+}
+
+export default async function ProductPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const product = await getProductBySlug(slug);
+  if (!product) notFound();
+
+  return (
+    <article className="section-shell py-16 sm:py-20">
+      <div className="mx-auto max-w-4xl space-y-6">
+        <h1 className="text-4xl font-semibold text-charcoal">{product.name}</h1>
+        <div className="relative aspect-[16/9] overflow-hidden rounded-3xl">
+          <Image src={product.image} alt={product.name} fill className="object-cover" sizes="100vw" />
+        </div>
+        <p className="inline-flex rounded-full bg-nude px-4 py-2 text-sm font-medium text-charcoal">{product.price}</p>
+        <p className="text-base leading-8 text-charcoal/85">{product.description}</p>
+        <div className="flex gap-3">
+          <ButtonLink href={productWhatsAppLink(product.name)} variant="primary" external>
+            Buy / Enquire on WhatsApp
+          </ButtonLink>
+          <ButtonLink href="/products" variant="secondary">
+            Back to products
+          </ButtonLink>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,33 @@
 import type { MetadataRoute } from 'next';
+import { getCourses } from '@/data/courses';
+import { getProducts } from '@/data/products';
 import { siteConfig } from '@/data/site';
 
 const routes = ['', '/courses', '/upcoming-classes', '/gallery', '/products', '/register', '/contact'];
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return routes.map((route) => ({
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [courses, products] = await Promise.all([getCourses(), getProducts()]);
+
+  const staticRoutes: MetadataRoute.Sitemap = routes.map((route) => ({
     url: `${siteConfig.url}${route}`,
     lastModified: new Date(),
     changeFrequency: route === '' ? 'weekly' : 'monthly',
     priority: route === '' ? 1 : 0.8
   }));
+
+  const courseRoutes: MetadataRoute.Sitemap = courses.map((course) => ({
+    url: `${siteConfig.url}/courses/${course.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7
+  }));
+
+  const productRoutes: MetadataRoute.Sitemap = products.map((product) => ({
+    url: `${siteConfig.url}/products/${product.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: 0.7
+  }));
+
+  return [...staticRoutes, ...courseRoutes, ...productRoutes];
 }

--- a/src/components/product-card.tsx
+++ b/src/components/product-card.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Product } from '@/data/products';
 import { productWhatsAppLink } from '@/lib/whatsapp';
 import { ButtonLink } from './button-link';
@@ -11,7 +12,11 @@ export function ProductCard({ product }: { product: Product }) {
       </div>
       <div className="space-y-4 p-6">
         <div className="flex items-start justify-between gap-4">
-          <h3 className="text-xl font-semibold text-charcoal">{product.name}</h3>
+          <h3 className="text-xl font-semibold text-charcoal">
+            <Link href={`/products/${product.slug}`} className="hover:underline">
+              {product.name}
+            </Link>
+          </h3>
           <span className="rounded-full bg-nude px-4 py-2 text-sm font-medium text-charcoal">{product.price}</span>
         </div>
         <p className="text-sm leading-7 text-charcoal/70">{product.description}</p>

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,6 +1,8 @@
 import { getSedifexIntegrationProducts, type SedifexCatalogItem } from '@/lib/server/sedifex';
 
 export type Product = {
+  slug: string;
+  id?: string;
   name: string;
   image: string;
   description: string;
@@ -8,9 +10,19 @@ export type Product = {
 };
 
 export const products: Product[] = [
-  { name: 'Radiance Facial Kit', image: '/uploads/products/radiance-facial-kit.svg', description: 'A classroom favourite skincare set for cleansing, exfoliating, and finishing facials.', price: 'GH₵ 240' },
-  { name: 'Pro Brush Collection', image: '/uploads/products/pro-brush-collection.svg', description: 'Premium multi-use brushes for flawless beauty therapy and make-up application.', price: 'GH₵ 180' }
+  { slug: 'radiance-facial-kit', name: 'Radiance Facial Kit', image: '/uploads/products/radiance-facial-kit.svg', description: 'A classroom favourite skincare set for cleansing, exfoliating, and finishing facials.', price: 'GH₵ 240' },
+  { slug: 'pro-brush-collection', name: 'Pro Brush Collection', image: '/uploads/products/pro-brush-collection.svg', description: 'Premium multi-use brushes for flawless beauty therapy and make-up application.', price: 'GH₵ 180' }
 ];
+
+function toSlug(name: string) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function makeStableSlug(item: SedifexCatalogItem) {
+  const baseSlug = toSlug(item.name);
+  if (!item.id) return baseSlug;
+  return `${baseSlug}-${item.id.slice(-6).toLowerCase()}`;
+}
 
 function formatPrice(value?: number) {
   if (typeof value !== 'number') return 'Price on request';
@@ -25,6 +37,8 @@ export async function getProducts() {
     const normalizedProducts = productItems.length ? productItems : ((catalog?.publicProducts || []) as SedifexCatalogItem[]);
     if (normalizedProducts.length) {
       return normalizedProducts.map((item) => ({
+        slug: makeStableSlug(item),
+        id: item.id,
         name: item.name,
         image: item.imageUrl || '/uploads/products/radiance-facial-kit.svg',
         description: item.description || 'Professional beauty product',
@@ -36,4 +50,9 @@ export async function getProducts() {
   }
 
   return products;
+}
+
+export async function getProductBySlug(slug: string) {
+  const allProducts = await getProducts();
+  return allProducts.find((product) => product.slug === slug) || null;
 }


### PR DESCRIPTION
### Motivation
- Provide stable, SEO-friendly detail pages for products and Sedifex-backed services so each item has a crawlable URL and unique metadata.
- Surface product image, description and price on indexable pages sourced from Sedifex fields with local fallbacks.
- Ensure dynamic product and course URLs are discoverable via the generated `sitemap` for better indexing.

### Description
- Added stable slug generation and product metadata in `src/data/products.ts` by introducing `slug`, optional `id`, `toSlug` and `makeStableSlug`, and the helper `getProductBySlug` so Slugs combine a normalized name plus an `id` suffix when available.
- Implemented an indexable product detail route at `src/app/products/[slug]/page.tsx` with `generateStaticParams`, per-product `title`/`description` metadata, canonical alternates, and on-page image/description/price rendering sourced from `getProducts()`.
- Updated `src/components/product-card.tsx` to link product names to `/products/{slug}` so internal pages are crawlable, and improved course metadata/canonical behavior in `src/app/courses/[slug]/page.tsx`.
- Extended `src/app/sitemap.ts` to include dynamic course and product detail URLs by loading `getCourses()` and `getProducts()` and appending those routes to the sitemap output.

### Testing
- Ran `npm run typecheck` (i.e. `tsc --noEmit`) which passed after the sitemap typing fix.
- `next build` previously failed due to a sitemap typing issue that was addressed in this PR (type errors resolved and rechecked with `tsc`).
- `npm run lint` (`next lint`) currently fails in this environment due to repository/tooling path resolution (`Invalid project directory provided`), which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065dd1805483218e4af5746ce950a4)