### PR TITLE
Normalize catalog descriptions, render multi-paragraph blocks, resilient Sedifex parsing, and add mobile nav toggle

### DIFF
--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { getCourseBySlug, getCourses } from '@/data/courses';
+import { toDescriptionBlocks } from '@/lib/content-format';
 import { ButtonLink } from '@/components/button-link';
 import { registerWhatsAppLink } from '@/lib/whatsapp';
 
@@ -25,6 +26,7 @@ export default async function CoursePage({ params }: { params: Promise<{ slug: s
   const { slug } = await params;
   const course = await getCourseBySlug(slug);
   if (!course) notFound();
+  const summaryBlocks = toDescriptionBlocks(course.summary);
 
   return (
     <article className="section-shell py-16 sm:py-20">
@@ -33,7 +35,11 @@ export default async function CoursePage({ params }: { params: Promise<{ slug: s
         <div className="relative aspect-[16/9] overflow-hidden rounded-3xl">
           <Image src={course.image} alt={course.imageAlt} fill className="object-cover" sizes="100vw" />
         </div>
-        <p className="text-base leading-8 text-charcoal/85">{course.summary}</p>
+        <div className="space-y-4 text-base leading-8 text-charcoal/85">
+          {summaryBlocks.map((block) => (
+            <p key={block}>{block}</p>
+          ))}
+        </div>
         <div className="flex gap-3">
           <ButtonLink href="/register" variant="primary">Apply now</ButtonLink>
           <ButtonLink href={registerWhatsAppLink(course.name)} variant="secondary" external>

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { ButtonLink } from '@/components/button-link';
 import { getProductBySlug, getProducts } from '@/data/products';
+import { toDescriptionBlocks } from '@/lib/content-format';
 import { productWhatsAppLink } from '@/lib/whatsapp';
 
 export async function generateStaticParams() {
@@ -27,6 +28,7 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
   const { slug } = await params;
   const product = await getProductBySlug(slug);
   if (!product) notFound();
+  const descriptionBlocks = toDescriptionBlocks(product.description);
 
   return (
     <article className="section-shell py-16 sm:py-20">
@@ -36,7 +38,11 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
           <Image src={product.image} alt={product.name} fill className="object-cover" sizes="100vw" />
         </div>
         <p className="inline-flex rounded-full bg-nude px-4 py-2 text-sm font-medium text-charcoal">{product.price}</p>
-        <p className="text-base leading-8 text-charcoal/85">{product.description}</p>
+        <div className="space-y-4 text-base leading-8 text-charcoal/85">
+          {descriptionBlocks.map((block) => (
+            <p key={block}>{block}</p>
+          ))}
+        </div>
         <div className="flex gap-3">
           <ButtonLink href={productWhatsAppLink(product.name)} variant="primary" external>
             Buy / Enquire on WhatsApp

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { navigation, siteConfig } from '@/data/site';
 import { cn } from '@/lib/utils';
@@ -8,6 +9,9 @@ import { createWhatsAppLink } from '@/lib/whatsapp';
 
 export function Header() {
   const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const closeMenu = () => setIsMenuOpen(false);
 
   return (
     <header className="sticky top-0 z-50 border-b border-white/70 bg-white/85 backdrop-blur-xl">
@@ -39,13 +43,35 @@ export function Header() {
         >
           Chat on WhatsApp
         </Link>
+        <button
+          type="button"
+          aria-label="Toggle navigation menu"
+          aria-expanded={isMenuOpen}
+          aria-controls="mobile-nav"
+          className="inline-flex items-center justify-center rounded-full border border-black/10 p-2 text-charcoal lg:hidden"
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+        >
+          <span className="sr-only">Menu</span>
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            {isMenuOpen ? (
+              <path d="M6 6l12 12M18 6L6 18" />
+            ) : (
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            )}
+          </svg>
+        </button>
       </div>
-      <nav aria-label="Mobile navigation" className="border-t border-black/5 px-4 py-3 lg:hidden">
+      <nav
+        id="mobile-nav"
+        aria-label="Mobile navigation"
+        className={cn('border-t border-black/5 px-4 py-3 lg:hidden', isMenuOpen ? 'block' : 'hidden')}
+      >
         <div className="flex gap-2 overflow-x-auto pb-1">
           {navigation.map((item) => (
             <Link
               key={item.href}
               href={item.href}
+              onClick={closeMenu}
               className={cn(
                 'whitespace-nowrap rounded-full px-4 py-2 text-sm transition',
                 pathname === item.href ? 'bg-charcoal text-white' : 'bg-nude text-charcoal/80'

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,4 +1,5 @@
 import { getSedifexIntegrationProducts, type SedifexCatalogItem } from '@/lib/server/sedifex';
+import { cleanCatalogDescription } from '@/lib/content-format';
 
 export type Course = {
   slug: string;
@@ -31,7 +32,7 @@ export async function getCourses() {
         slug: toSlug(service.name),
         name: service.name,
         duration: 'See schedule',
-        summary: service.description || 'Professional training program',
+        summary: cleanCatalogDescription(service.description) || 'Professional training program',
         category: 'Short Course' as const,
         image: service.imageUrl || '/uploads/courses/WhatsApp Image 2026-03-21 at 17.57.49.jpeg',
         imageAlt: service.imageAlt || service.name

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,4 +1,5 @@
 import { getSedifexIntegrationProducts, type SedifexCatalogItem } from '@/lib/server/sedifex';
+import { cleanCatalogDescription } from '@/lib/content-format';
 
 export type Product = {
   slug: string;
@@ -41,7 +42,7 @@ export async function getProducts() {
         id: item.id,
         name: item.name,
         image: item.imageUrl || '/uploads/products/radiance-facial-kit.svg',
-        description: item.description || 'Professional beauty product',
+        description: cleanCatalogDescription(item.description) || 'Professional beauty product',
         price: formatPrice(item.price)
       }));
     }

--- a/src/data/upcoming-classes.ts
+++ b/src/data/upcoming-classes.ts
@@ -15,8 +15,14 @@ export async function getUpcomingClasses() {
   try {
     const [availability, catalog] = await Promise.all([getSedifexAvailability(), getSedifexIntegrationProducts()]);
     const services = new Map<string, SedifexCatalogItem>();
-    for (const item of (catalog?.publicServices || []) as SedifexCatalogItem[]) services.set(item.id, item);
-    const slots = availability?.slots || [];
+    const rawCatalog = [
+      ...(((catalog as any)?.publicServices || []) as SedifexCatalogItem[]),
+      ...(((catalog as any)?.services || []) as SedifexCatalogItem[]),
+      ...((((catalog as any)?.products || []) as SedifexCatalogItem[]).filter((item) => item.itemType?.toLowerCase() === 'service'))
+    ];
+    for (const item of rawCatalog) services.set(item.id, item);
+
+    const slots = (availability as any)?.slots || (availability as any)?.availability || (availability as any)?.data?.slots || [];
     if (slots.length) {
       return slots.map((slot: any) => {
         const service = services.get(slot.serviceId);

--- a/src/lib/content-format.ts
+++ b/src/lib/content-format.ts
@@ -1,0 +1,27 @@
+export function cleanCatalogDescription(value?: string) {
+  if (!value) return '';
+
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^\*\*|\*\*$/g, ''));
+
+  const filtered = lines.filter((line) => {
+    const lower = line.toLowerCase();
+    return !lower.startsWith('product name:') && !lower.startsWith('item type:');
+  });
+
+  return filtered.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+export function toDescriptionBlocks(value?: string) {
+  const cleaned = cleanCatalogDescription(value);
+  if (!cleaned) return [];
+
+  return cleaned
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => block.replace(/\*\*/g, ''));
+}


### PR DESCRIPTION
### Motivation
- Ensure product and course descriptions imported from the Sedifex catalog are cleaned of noisy metadata and preserve paragraph structure for proper rendering.
- Make upcoming-classes parsing more resilient to variations in the Sedifex integration payload shape.
- Add a client-side mobile navigation toggle so the header is usable on small screens.

### Description
- Add `src/lib/content-format.ts` providing `cleanCatalogDescription` to strip metadata and normalize line breaks and `toDescriptionBlocks` to split cleaned text into paragraph blocks.
- Use `cleanCatalogDescription` when normalizing external catalog items in `src/data/products.ts` and `src/data/courses.ts` so `description`/`summary` values are cleaned before use.
- Render multi-paragraph descriptions on the product and course pages by calling `toDescriptionBlocks` and mapping blocks to `<p>` elements in `src/app/products/[slug]/page.tsx` and `src/app/courses/[slug]/page.tsx`.
- Make Sedifex catalog and availability parsing in `src/data/upcoming-classes.ts` tolerant to different property shapes by aggregating `services`, `publicServices`, and `products` and checking multiple availability fields.
- Add a client-side mobile navigation menu in `src/components/header.tsx` using `useState`, a toggle button with ARIA attributes, and closing the menu on link click.

### Testing
- Ran a project build/type-check (`npm run build`) and a dev server smoke start (`npm run dev`); both completed successfully with no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0661f6e1a48321917528ef25ff2aee)