### PR TITLE
Fix missing GitHub images and add site logo/favicon metadata

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,11 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'us-central1-sedifex-web.cloudfunctions.net' },
       { protocol: 'https', hostname: 'firebasestorage.googleapis.com' },
       { protocol: 'https', hostname: 'storage.googleapis.com' },
-      { protocol: 'https', hostname: '*.googleusercontent.com' }
+      { protocol: 'https', hostname: '*.googleusercontent.com' },
+      { protocol: 'https', hostname: 'raw.githubusercontent.com' },
+      { protocol: 'https', hostname: 'github.com' },
+      { protocol: 'https', hostname: 'user-images.githubusercontent.com' },
+      { protocol: 'https', hostname: 'avatars.githubusercontent.com' }
     ]
   }
 };

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Make Up &amp; More School of Cosmetology logo</title>
+  <desc id="desc">Rounded emblem with initials MM and a beauty brush accent.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f8e9b0"/>
+      <stop offset="100%" stop-color="#d4af37"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <circle cx="256" cy="256" r="186" fill="none" stroke="url(#gold)" stroke-width="18"/>
+  <path d="M140 330V182h46l70 93 70-93h46v148h-44v-79l-72 93-72-93v79z" fill="url(#gold)"/>
+  <path d="M356 142l60-34 18 32-58 34z" fill="url(#gold)"/>
+  <circle cx="433" cy="130" r="13" fill="#f8e9b0"/>
+</svg>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Make Up &amp; More School of Cosmetology logo</title>
+  <desc id="desc">Rounded emblem with initials MM and a beauty brush accent.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f8e9b0"/>
+      <stop offset="100%" stop-color="#d4af37"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <circle cx="256" cy="256" r="186" fill="none" stroke="url(#gold)" stroke-width="18"/>
+  <path d="M140 330V182h46l70 93 70-93h46v148h-44v-79l-72 93-72-93v79z" fill="url(#gold)"/>
+  <path d="M356 142l60-34 18 32-58 34z" fill="url(#gold)"/>
+  <circle cx="433" cy="130" r="13" fill="#f8e9b0"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,12 +19,19 @@ export const metadata: Metadata = {
     description: siteConfig.description,
     type: 'website',
     locale: 'en_GH',
-    siteName: siteConfig.name
+    siteName: siteConfig.name,
+    images: [{ url: '/logo.svg', alt: `${siteConfig.name} logo` }]
   },
   twitter: {
     card: 'summary_large_image',
     title: siteConfig.name,
-    description: siteConfig.description
+    description: siteConfig.description,
+    images: ['/logo.svg']
+  },
+  icons: {
+    icon: '/logo.svg',
+    shortcut: '/logo.svg',
+    apple: '/logo.svg'
   }
 };
 


### PR DESCRIPTION
### Motivation
- External images hosted on GitHub were not being optimized/served by Next.js and the site needed a persistent brand icon for browser tabs and social previews.
- Improve appearance of site previews (Open Graph/Twitter) and provide a favicon/address-bar icon for consistent branding.

### Description
- Added common GitHub image hosts to Next.js image `remotePatterns` in `next.config.ts` (`raw.githubusercontent.com`, `github.com`, `user-images.githubusercontent.com`, `avatars.githubusercontent.com`).
- Added a new brand asset `public/logo.svg` containing the site logo and copied the same SVG to `src/app/icon.svg` so the App Router can expose a favicon.
- Updated root metadata in `src/app/layout.tsx` to include Open Graph `images`, Twitter `images`, and `icons` (`icon`, `shortcut`, `apple`) that reference `/logo.svg` so previews and browser UI use the new logo.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with static/SSG routes generated.
- Ran `npm run lint` which failed due to a repository-specific lint script configuration (invalid `/workspace/makeupschool/lint` path) and is unrelated to the changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cb89ccd48321b9537ea5167d0f00)