### PR TITLE
Hide empty gallery, update gallery copy, and improve mobile hamburger

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,11 @@ import { homepageImages } from '@/data/media-library';
 import { testimonials } from '@/data/testimonials';
 import { siteConfig } from '@/data/site';
 import { createWhatsAppLink } from '@/lib/whatsapp';
+import { getGalleryItems } from '@/data/gallery';
 
 export default async function HomePage() {
   const classes = await getUpcomingClasses();
+  const galleryItems = await getGalleryItems();
   return (
     <div>
       <section className="bg-hero-glow">
@@ -216,19 +218,21 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="section-shell py-20">
-        <SectionHeading
-          eyebrow="Student work"
-          title="A glimpse into practical sessions, polished beauty looks, and classroom energy."
-          description="The gallery now reads from the dedicated public/uploads/gallery folder so future student work is simple to refresh."
-        />
-        <div className="mt-10">
-          <GalleryGrid limit={4} />
-        </div>
-        <div className="mt-8">
-          <ButtonLink href="/gallery" variant="secondary">Browse full gallery</ButtonLink>
-        </div>
-      </section>
+      {galleryItems.length > 0 ? (
+        <section className="section-shell py-20">
+          <SectionHeading
+            eyebrow="Student work"
+            title="A glimpse into practical sessions, polished beauty looks, and classroom energy."
+            description="Explore real classroom practice, finished beauty looks, and the supportive learning atmosphere at Make Up & More School."
+          />
+          <div className="mt-10">
+            <GalleryGrid limit={4} items={galleryItems} />
+          </div>
+          <div className="mt-8">
+            <ButtonLink href="/gallery" variant="secondary">Browse full gallery</ButtonLink>
+          </div>
+        </section>
+      ) : null}
 
       <section className="section-shell py-20">
         <SectionHeading

--- a/src/components/gallery-grid.tsx
+++ b/src/components/gallery-grid.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
-import { getGalleryItems } from '@/data/gallery';
+import { GalleryItem, getGalleryItems } from '@/data/gallery';
 
-export async function GalleryGrid({ limit }: { limit?: number }) {
-  const galleryItems = await getGalleryItems();
+export async function GalleryGrid({ limit, items: presetItems }: { limit?: number; items?: GalleryItem[] }) {
+  const galleryItems = presetItems ?? (await getGalleryItems());
   const items = limit ? galleryItems.slice(0, limit) : galleryItems;
 
   return (

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,7 +21,7 @@ export function Header() {
           <span className="text-lg font-semibold tracking-tight text-charcoal sm:text-xl">{siteConfig.shortName}</span>
           <span className="block text-xs text-charcoal/60">School of Cosmetology</span>
         </Link>
-        <nav aria-label="Primary navigation" className="hidden items-center gap-1 lg:flex">
+        <nav aria-label="Primary navigation" className="hidden items-center gap-1 xl:flex">
           {navigation.map((item) => (
             <Link
               key={item.href}
@@ -48,7 +48,7 @@ export function Header() {
           aria-label="Toggle navigation menu"
           aria-expanded={isMenuOpen}
           aria-controls="mobile-nav"
-          className="inline-flex items-center justify-center rounded-full border border-black/10 p-2 text-charcoal lg:hidden"
+          className="inline-flex items-center justify-center rounded-full border border-black/10 p-2 text-charcoal xl:hidden"
           onClick={() => setIsMenuOpen((prev) => !prev)}
         >
           <span className="sr-only">Menu</span>
@@ -64,16 +64,16 @@ export function Header() {
       <nav
         id="mobile-nav"
         aria-label="Mobile navigation"
-        className={cn('border-t border-black/5 px-4 py-3 lg:hidden', isMenuOpen ? 'block' : 'hidden')}
+        className={cn('border-t border-black/5 px-4 py-3 xl:hidden', isMenuOpen ? 'block' : 'hidden')}
       >
-        <div className="flex gap-2 overflow-x-auto pb-1">
+        <div className="flex flex-col gap-2">
           {navigation.map((item) => (
             <Link
               key={item.href}
               href={item.href}
               onClick={closeMenu}
               className={cn(
-                'whitespace-nowrap rounded-full px-4 py-2 text-sm transition',
+                'rounded-2xl px-4 py-3 text-sm transition',
                 pathname === item.href ? 'bg-charcoal text-white' : 'bg-nude text-charcoal/80'
               )}
             >


### PR DESCRIPTION
### Motivation
- Prevent empty gallery UI from appearing when there are no uploaded photos by only rendering the Student Work section when images exist. 
- Replace implementation/folder-centric gallery copy with school-focused text so the site reads like a school site rather than developer notes. 
- Make the navigation hamburger available on phones/tablets and show the inline desktop nav at larger breakpoints for a better mobile experience.

### Description
- Prefetches gallery data in the homepage by calling `getGalleryItems()` in `src/app/page.tsx` and conditionally renders the Student Work section only when `galleryItems.length > 0`.
- Rewrote the Student Work description to school-focused language in `src/app/page.tsx` and passes the pre-fetched `galleryItems` into the grid via `GalleryGrid` to avoid double-loading.
- Updated `GalleryGrid` in `src/components/gallery-grid.tsx` to accept an optional `items?: GalleryItem[]` prop and import the `GalleryItem` type so pages can provide pre-fetched items or fall back to `getGalleryItems()`.
- Adjusted header responsive classes in `src/components/header.tsx` so the inline nav appears at `xl` and above, the hamburger button is visible below `xl`, and the mobile menu is a stacked, tap-friendly list with updated spacing and rounded styles.

### Testing
- `npm run build` (Next.js production build) completed successfully and static pages were generated. 
- `npm run lint` failed due to the project lint script resolving to a non-existent `/workspace/makeupschool/lint` path, producing a configuration error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cda9a1cc8321b37053cada11c44f)