### PR TITLE
Load homepage student-work images from uploads and generate gallery from local files

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import Image from 'next/image';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
 import { ButtonLink } from '@/components/button-link';
 import { CourseCard } from '@/components/course-card';
 import { GalleryGrid } from '@/components/gallery-grid';
@@ -13,9 +15,33 @@ import { siteConfig } from '@/data/site';
 import { createWhatsAppLink } from '@/lib/whatsapp';
 import { getGalleryItems } from '@/data/gallery';
 
+type StudentWorkImage = {
+  title: string;
+  src: string;
+  alt: string;
+};
+
+async function getHomepageStudentWork(): Promise<StudentWorkImage[]> {
+  const homepageDir = path.join(process.cwd(), 'public/uploads/homepage');
+  const entries = await readdir(homepageDir, { withFileTypes: true });
+  const fileNames = entries
+    .filter((entry) => entry.isFile() && /\.(jpe?g|png|webp|avif)$/i.test(entry.name))
+    .map((entry) => entry.name)
+    .filter((name) => /^hairdress(?:ing|ig) braids \d+\.jpe?g$/i.test(name))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+  return fileNames.map((name, index) => ({
+    title: index < 4 ? `Braids practical look ${index + 1}` : `Makeup practical look ${index - 3}`,
+    src: `/uploads/homepage/${name}`,
+    alt: `Student practical look ${index + 1}`
+  }));
+}
+
 export default async function HomePage() {
   const classes = await getUpcomingClasses();
   const galleryItems = await getGalleryItems();
+  const braidsAndMakeupImages = await getHomepageStudentWork();
+  const practicalLooks = braidsAndMakeupImages.length ? braidsAndMakeupImages : homepageImages.braids;
   return (
     <div>
       <section className="bg-hero-glow">
@@ -130,7 +156,7 @@ export default async function HomePage() {
           description="The first four photos highlight braiding practice, and the next four feature makeup practical work from class sessions."
         />
         <div className="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-          {homepageImages.braids.map((item) => (
+          {practicalLooks.map((item) => (
             <figure key={item.title} className="overflow-hidden rounded-4xl border border-black/5 bg-white shadow-card">
               <div className="relative aspect-[4/5] bg-gradient-to-br from-white via-nude to-blush">
                 <Image

--- a/src/data/gallery.ts
+++ b/src/data/gallery.ts
@@ -1,6 +1,5 @@
 import { readdir } from 'node:fs/promises';
 import path from 'node:path';
-import { getSedifexGallery } from '@/lib/server/sedifex';
 
 export type GalleryItem = {
   title: string;
@@ -10,27 +9,25 @@ export type GalleryItem = {
 
 const GALLERY_DIR = path.join(process.cwd(), 'public/uploads/gallery');
 const GALLERY_WEB_PATH = '/uploads/gallery';
+const SUPPORTED_EXTENSIONS = /\.(jpe?g|png|webp|avif)$/i;
+const EXCLUDED_FILE_STEMS = new Set(['braids-and-protective-styling', 'student-practical-facial-session']);
+
+function toProfessionalTitle(index: number) {
+  return `Student Signature Look ${String(index + 1).padStart(2, '0')}`;
+}
 
 export async function getGalleryItems(): Promise<GalleryItem[]> {
-  try {
-    const sedifex = await getSedifexGallery();
-    if (sedifex?.gallery?.length) {
-      return sedifex.gallery
-        .filter((item: { isPublished?: boolean }) => item.isPublished !== false)
-        .sort((a: { sortOrder?: number }, b: { sortOrder?: number }) => (a.sortOrder ?? 9999) - (b.sortOrder ?? 9999))
-        .map((item: { caption?: string; alt?: string; url: string }) => ({
-          title: item.caption || item.alt || 'School Gallery',
-          category: 'Sedifex Gallery',
-          image: item.url
-        }));
-    }
-  } catch (error) {
-    console.warn('Falling back to local gallery files:', error);
-  }
-
   const entries = await readdir(GALLERY_DIR, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isFile() && /\.(jpe?g|png|webp|avif|svg)$/i.test(entry.name))
-    .map((entry) => ({ title: entry.name.replace(/\.[^.]+$/, ''), category: 'School Gallery', image: `${GALLERY_WEB_PATH}/${entry.name}` }))
-    .sort((a, b) => a.title.localeCompare(b.title));
+
+  const fileNames = entries
+    .filter((entry) => entry.isFile() && SUPPORTED_EXTENSIONS.test(entry.name))
+    .map((entry) => entry.name)
+    .filter((name) => !EXCLUDED_FILE_STEMS.has(name.replace(/\.[^.]+$/, '').toLowerCase()))
+    .sort((a, b) => a.localeCompare(b));
+
+  return fileNames.map((fileName, index) => ({
+    title: toProfessionalTitle(index),
+    category: 'Student Work',
+    image: `${GALLERY_WEB_PATH}/${fileName}`
+  }));
 }


### PR DESCRIPTION
### Motivation

- Surface recent student practical photos on the homepage from the `public/uploads` folder instead of relying solely on hard-coded assets. 
- Simplify and standardize gallery generation by using local uploads and consistent titles for student work rather than an external Sedifex feed. 

### Description

- Added `getHomepageStudentWork` to `src/app/page.tsx` which reads `public/uploads/homepage`, filters image files by pattern, builds `practicalLooks`, and replaces `homepageImages.braids` usage. 
- Imported `readdir` and `path` and introduced the `StudentWorkImage` type in `page.tsx` to model homepage images. 
- Rewrote `src/data/gallery.ts` to remove the Sedifex dependency and instead read `public/uploads/gallery`, filter by supported image extensions, exclude configured file stems, sort entries, and emit `GalleryItem`s with generated titles via `toProfessionalTitle` and category `Student Work`. 
- Added `SUPPORTED_EXTENSIONS`, `EXCLUDED_FILE_STEMS`, and a filename-to-title mapping to ensure predictable ordering and naming. 

### Testing

- Ran the TypeScript type check via `tsc --noEmit` and it succeeded. 
- Executed the project test suite with `pnpm test` and all tests passed. 
- Performed a production build with `pnpm build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f6ecf0308321b1757526b59e9b75)