### PR TITLE
Pull live Sedifex availability for upcoming classes

### DIFF
--- a/src/data/upcoming-classes.ts
+++ b/src/data/upcoming-classes.ts
@@ -1,47 +1,187 @@
-import { getSedifexAvailability, getSedifexIntegrationProducts, type SedifexCatalogItem } from '@/lib/server/sedifex';
+import {
+  getSedifexAvailability,
+  getSedifexIntegrationProducts,
+  type SedifexAvailabilitySlot,
+  type SedifexCatalogItem
+} from '@/lib/server/sedifex';
 
-export type UpcomingClass = { id: string; name: string; image: string; imageAlt: string; startDate: string; duration: string; schedule: string; slots: string; category: 'Full Programs' | 'Short Courses' };
+export type UpcomingClass = {
+  id: string;
+  name: string;
+  image: string;
+  imageAlt: string;
+  startDate: string;
+  duration: string;
+  schedule: string;
+  slots: string;
+  category: 'Full Programs' | 'Short Courses';
+};
 
 export const upcomingClasses: UpcomingClass[] = [
-  { id: 'beauty-therapy-april', name: 'Beauty Therapy', image: '/uploads/courses/WhatsApp Image 2026-03-21 at 17.57.49 (1).jpeg', imageAlt: 'Beauty therapy practical training in session', startDate: '12 April 2026', duration: '6 months', schedule: 'Weekday • Morning', slots: 'Limited slots', category: 'Full Programs' }
+  {
+    id: 'beauty-therapy-april',
+    name: 'Beauty Therapy',
+    image: '/uploads/courses/WhatsApp Image 2026-03-21 at 17.57.49 (1).jpeg',
+    imageAlt: 'Beauty therapy practical training in session',
+    startDate: '12 April 2026',
+    duration: '6 months',
+    schedule: 'Weekday • Morning',
+    slots: 'Limited slots',
+    category: 'Full Programs'
+  }
 ];
 
 function fmtDate(value?: string) {
   if (!value) return 'TBA';
-  return new Date(value).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'TBA';
+
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  });
+}
+
+function fmtTime(value?: string) {
+  if (!value) return '';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  return date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function fmtSchedule(slot: SedifexAvailabilitySlot) {
+  const start = fmtTime(slot.startAt);
+  const end = fmtTime(slot.endAt);
+  const timezone = slot.timezone || 'Africa/Accra';
+
+  if (start && end) return `${start} - ${end} • ${timezone}`;
+  if (start) return `${start} • ${timezone}`;
+
+  return timezone;
+}
+
+function fmtDuration(slot: SedifexAvailabilitySlot, service?: SedifexCatalogItem) {
+  if (service?.duration) return service.duration;
+
+  if (!slot.startAt || !slot.endAt) return 'See class details';
+
+  const start = new Date(slot.startAt).getTime();
+  const end = new Date(slot.endAt).getTime();
+
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) {
+    return 'See class details';
+  }
+
+  const minutes = Math.round((end - start) / 60000);
+
+  if (minutes < 60) return `${minutes} minutes`;
+
+  const hours = minutes / 60;
+  return Number.isInteger(hours) ? `${hours} hour${hours === 1 ? '' : 's'}` : `${hours.toFixed(1)} hours`;
+}
+
+function fmtSlots(slot: SedifexAvailabilitySlot) {
+  const remaining = Number(slot.seatsRemaining);
+  const capacity = Number(slot.capacity);
+
+  if (Number.isFinite(remaining)) {
+    if (remaining <= 0) return 'Waitlist';
+    return `${remaining} seat${remaining === 1 ? '' : 's'} left`;
+  }
+
+  if (Number.isFinite(capacity) && capacity > 0) {
+    return `${capacity} seats available`;
+  }
+
+  return 'Limited slots';
+}
+
+function getCategory(service?: SedifexCatalogItem): UpcomingClass['category'] {
+  const value = `${service?.category || service?.itemType || ''}`.toLowerCase();
+
+  if (value.includes('full') || value.includes('program')) return 'Full Programs';
+
+  return 'Short Courses';
+}
+
+function extractSlots(payload: unknown): SedifexAvailabilitySlot[] {
+  const data = payload as any;
+
+  const slots =
+    data?.slots ||
+    data?.availability ||
+    data?.data?.slots ||
+    data?.data?.availability ||
+    [];
+
+  return Array.isArray(slots) ? slots : [];
+}
+
+function extractServices(payload: unknown): SedifexCatalogItem[] {
+  const data = payload as any;
+
+  return [
+    ...((data?.publicServices || []) as SedifexCatalogItem[]),
+    ...((data?.services || []) as SedifexCatalogItem[]),
+    ...(((data?.products || []) as SedifexCatalogItem[]).filter((item) => item.itemType?.toLowerCase() === 'service'))
+  ];
 }
 
 export async function getUpcomingClasses() {
   try {
-    const [availability, catalog] = await Promise.all([getSedifexAvailability(), getSedifexIntegrationProducts()]);
-    const services = new Map<string, SedifexCatalogItem>();
-    const rawCatalog = [
-      ...(((catalog as any)?.publicServices || []) as SedifexCatalogItem[]),
-      ...(((catalog as any)?.services || []) as SedifexCatalogItem[]),
-      ...((((catalog as any)?.products || []) as SedifexCatalogItem[]).filter((item) => item.itemType?.toLowerCase() === 'service'))
-    ];
-    for (const item of rawCatalog) services.set(item.id, item);
+    const fromDate = new Date();
+    const toDate = new Date();
+    toDate.setDate(toDate.getDate() + 120);
 
-    const slots = (availability as any)?.slots || (availability as any)?.availability || (availability as any)?.data?.slots || [];
+    const [availability, catalog] = await Promise.all([
+      getSedifexAvailability({
+        from: fromDate.toISOString(),
+        to: toDate.toISOString()
+      }),
+      getSedifexIntegrationProducts()
+    ]);
+
+    const services = new Map<string, SedifexCatalogItem>();
+    for (const item of extractServices(catalog)) {
+      if (item.id) services.set(item.id, item);
+    }
+
+    const slots = extractSlots(availability)
+      .filter((slot) => !slot.status || slot.status.toLowerCase() === 'open')
+      .sort((a, b) => {
+        const first = new Date(a.startAt || 0).getTime();
+        const second = new Date(b.startAt || 0).getTime();
+        return first - second;
+      });
+
     if (slots.length) {
-      return slots.map((slot: any) => {
-        const service = services.get(slot.serviceId);
-        const seats = Number(slot.seatsRemaining ?? 0);
+      return slots.map((slot) => {
+        const service = slot.serviceId ? services.get(slot.serviceId) : undefined;
+        const level = typeof slot.attributes?.level === 'string' ? slot.attributes.level : '';
+
         return {
           id: slot.id,
-          name: service?.name || 'Class',
+          name: service?.name || level || 'Upcoming Class',
           image: service?.imageUrl || '/uploads/courses/WhatsApp Image 2026-03-21 at 17.57.49 (1).jpeg',
           imageAlt: service?.imageAlt || service?.name || 'Class image',
           startDate: fmtDate(slot.startAt),
-          duration: 'See class details',
-          schedule: slot.timezone || 'Scheduled',
-          slots: seats > 0 ? `${seats} seats left` : 'Waitlist',
-          category: 'Short Courses' as const
+          duration: fmtDuration(slot, service),
+          schedule: level ? `${fmtSchedule(slot)} • ${level}` : fmtSchedule(slot),
+          slots: fmtSlots(slot),
+          category: getCategory(service)
         };
       });
     }
   } catch (error) {
     console.warn('Falling back to local upcoming classes:', error);
   }
+
   return upcomingClasses;
 }

--- a/src/lib/server/sedifex.ts
+++ b/src/lib/server/sedifex.ts
@@ -74,6 +74,25 @@ export type SedifexCatalogItem = {
   imageAlt?: string;
   price?: number;
   itemType?: string;
+  category?: string;
+  duration?: string;
+  schedule?: string;
+  attributes?: Record<string, unknown>;
+  updatedAt?: string;
+};
+
+export type SedifexAvailabilitySlot = {
+  id: string;
+  storeId?: string;
+  serviceId?: string;
+  startAt?: string;
+  endAt?: string;
+  timezone?: string;
+  capacity?: number;
+  seatsBooked?: number;
+  seatsRemaining?: number;
+  status?: string;
+  attributes?: Record<string, unknown>;
   updatedAt?: string;
 };
 
@@ -99,10 +118,17 @@ export async function getSedifexGallery() {
   return sedifexFetch(`/integrationGallery?storeId=${encodeURIComponent(storeId)}`, true);
 }
 
-export async function getSedifexAvailability() {
+export async function getSedifexAvailability(filters: { serviceId?: string; from?: string; to?: string } = {}) {
   const storeId = getStoreId();
   if (!storeId || !getApiKey()) return null;
-  return sedifexFetch(`/v1IntegrationAvailability?storeId=${encodeURIComponent(storeId)}`, true);
+
+  const params = new URLSearchParams({ storeId });
+
+  if (filters.serviceId) params.set('serviceId', filters.serviceId);
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+
+  return sedifexFetch(`/v1IntegrationAvailability?${params.toString()}`, true);
 }
 
 export async function getSedifexPublicBlog(slug?: string) {


### PR DESCRIPTION
### Motivation
- Surface real-time class/session availability from Sedifex on the Upcoming Classes page so public pages show accurate slots, times, and capacities.
- Add richer Sedifex types so service metadata and availability attributes can be mapped into the site’s UI.

### Description
- Updated `src/lib/server/sedifex.ts` to make `getSedifexAvailability()` accept optional `filters: { serviceId?: string; from?: string; to?: string }` and build query params with `URLSearchParams` for authenticated availability requests.
- Extended `SedifexCatalogItem` with optional `category`, `duration`, `schedule`, and `attributes`, and added a new `SedifexAvailabilitySlot` type to represent availability slots.
- Replaced `src/data/upcoming-classes.ts` logic to request availability for the next 120 days with `getSedifexAvailability({ from, to })`, fetch catalog via `getSedifexIntegrationProducts()`, join slots to services, filter to open/missing-status slots, sort by `startAt`, and map `seatsRemaining`, `capacity`, start/end times, timezone, `attributes.level`, service image, duration, schedule, and category; the module falls back to local `upcomingClasses` if Sedifex data is unavailable.
- Left `src/app/upcoming-classes/page.tsx` and the existing component wiring intact so the public page continues to render using `getUpcomingClasses()`.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run build` and the Next.js build completed without errors.
- Started the dev server with `npm run dev` and verified the route with `curl -I http://127.0.0.1:3000/upcoming-classes` which returned `HTTP/1.1 200 OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0793bc69c88321beac31c91fdccc00)